### PR TITLE
Indexing of all publicly queryable post types. fixes #53

### DIFF
--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -392,7 +392,7 @@ class SolrPower_Sync {
 
 				// now we actually gather the blog posts
 				$args	 = array(
-					'post_type'		 => $post_type,
+					'post_type'		 => apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) ),
 					'post_status'	 => 'publish',
 					'fields'		 => 'ids',
 					'posts_per_page' => absint( $limit ),
@@ -448,7 +448,7 @@ class SolrPower_Sync {
 			restore_current_blog();
 		} else {
 			$args		 = array(
-				'post_type'		 => $post_type,
+				'post_type'		 => apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) ),
 				'post_status'	 => 'publish',
 				'fields'		 => 'ids',
 				'posts_per_page' => absint( $limit ),
@@ -458,9 +458,9 @@ class SolrPower_Sync {
 			$posts		 = $query->posts;
 			$postcount	 = count( $posts );
 			if ( 0 == $postcount ) {
-				$end = true;
-				$results=sprintf( "{\"type\": \"" . $post_type . "\", \"last\": \"%s\", \"end\": true, \"percent\": \"%.2f\"}", $last, 100 );
-				if ($echo){
+				$end	 = true;
+				$results = sprintf( "{\"type\": \"" . $post_type . "\", \"last\": \"%s\", \"end\": true, \"percent\": \"%.2f\"}", $last, 100 );
+				if ( $echo ) {
 					echo $results;
 				}
 				die();

--- a/views/options/action.php
+++ b/views/options/action.php
@@ -32,29 +32,9 @@
 </tr>
 </form -->
 
-    <!-- tr valign="top">
-        <th scope="row"><?php _e('Load All Pages', 'solr4wp') ?></th>
-        <td><input type="submit" class="button-primary" name="s4wp_pageload" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
-    </tr>
-
-    <tr valign="top">
-        <th scope="row"><?php _e('Load All Posts', 'solr4wp') ?></th>
-        <td><input type="submit" class="button-primary" name="s4wp_postload['posts']" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
-    </tr -->
-
-<!--
-  Let's loop through each Post type, and give an option to add them into the
-  Solr index.
--->
-<?php
-  $postTypes = get_post_types(array( 'exclude_from_search' => false ));
-
-  foreach($postTypes as $postType) {
-?>
-<tr valign="top">
-    <th scope="row"><?php _e('Load All '.esc_html($postType).'(s)', 'solr4wp') ?></th>
-    <td><input type="button" class="button-primary s4wp_postload_<?php print(esc_attr($postType)); ?>" name="s4wp_postload_<?php print(esc_attr($postType)); ?>" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
+   <tr valign="top">
+    <th scope="row"><?php esc_html_e('Index Searchable Post Types', 'solr4wp') ?></th>
+    <td><input type="button" class="button-primary s4wp_postload_post" name="s4wp_postload_post" value="<?php _e('Execute', 'solr4wp') ?>" /></td>
 </tr>
-<?php } ?>
 </table>
 </div>


### PR DESCRIPTION
This makes the only indexing option to be all post types that are publicly searchable. Introduces a filter for post type list allowing developers to modify this list: 
`apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) )`