### PR TITLE
Filters for AJAX and admin integration. fixes #59

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -27,7 +27,13 @@ class SolrPower_WP_Query {
 
 	function __construct() {
 		// We don't want to do a Solr query if we're doing AJAX or in the admin area.
-		if ( ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || (is_admin()) ) {
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			if ( false === apply_filters( 'solr_allow_ajax', false ) ) {
+				return;
+			}
+		}
+
+		if ( is_admin() && false === apply_filters( 'solr_allow_admin', false ) ) {
 			return;
 		}
 
@@ -53,7 +59,7 @@ class SolrPower_WP_Query {
 		$count	 = $query->get( 'posts_per_page' );
 		$fq		 = array();
 		$sortby	 = (isset( $solr_options[ 's4wp_default_sort' ] ) && !empty( $solr_options[ 's4wp_default_sort' ] )) ? $solr_options[ 's4wp_default_sort' ] : 'score';
-		
+
 		$order	 = 'desc';
 		$search	 = SolrPower_Api::get_instance()->query( $qry, $offset, $count, $fq, $sortby, $order );
 		if ( is_null( $search ) ) {

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -21,17 +21,24 @@ class SolrPower_WP_Query {
 	public static function get_instance() {
 		if ( !self::$instance ) {
 			self::$instance = new self();
+			add_action( 'init', array( self::$instance, 'setup' ) );
 		}
 		return self::$instance;
 	}
 
 	function __construct() {
+		
+	}
+
+	function setup() {
 		// We don't want to do a Solr query if we're doing AJAX or in the admin area.
+
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			if ( false === apply_filters( 'solr_allow_ajax', false ) ) {
 				return;
 			}
 		}
+
 
 		if ( is_admin() && false === apply_filters( 'solr_allow_admin', false ) ) {
 			return;


### PR DESCRIPTION
Developers can use the `solr_allow_ajax` and the `solr_allow_admin` filters to allow Solr to work with AJAX and within the wp-admin area.  Fixes #59 