### PR TITLE
Add is_search check to found_posts_query filter

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -121,7 +121,9 @@ class SolrPower_WP_Query {
 	}
 
 	function found_posts_query( $sql, $query ) {
-
+		if ( !$query->is_search() ) {
+			return $sql;
+		}
 		return '';
 	}
 


### PR DESCRIPTION
This limits clearing of found posts query to solr searching.  Always returning blank breaks paging within wp install on non-search pages.