### PR TITLE
Fix exception handling in ping_server()

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -114,11 +114,11 @@ class SolrPower_Api {
 		try {
 			$solr->ping( $solr->createPing() );
 			return true;
-		} catch ( Solarium\Exception $e ) {
+		} catch ( Solarium\Exception\HttpException $e ) {
+		  	// TODO: log this and or otherwise react.
 			return false;
 		}
 	}
-
 	/**
 	 * Connect to the solr service
 	 * @return solr service object


### PR DESCRIPTION
it looks like we had the wrong exception address here, so we weren't catching failed pings.

This is a good way to potentially resolve #57 - we should have the initial admin page for the plugin do a ping, and if the result is a 404 _and_ we're on Pantheon, that's a clear signal that the schema needs to be posted. 

@allan23 - I think fixing the exception handler is a good idea regardless, and we probably want to at least log something if this happens in general. Let me know what you think about the above idea. If it's not crazy, then maybe we can get that in for the 0.3 release?