### PR TITLE
check get_solr result in ping_server

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -111,6 +111,9 @@ class SolrPower_Api {
 	 */
 	function ping_server() {
 		$solr = get_solr();
+		if (!$solr) {
+			return false;
+		}
 		try {
 			$solr->ping( $solr->createPing() );
 			return true;


### PR DESCRIPTION
We cannot open the solr-power configuration page in wp-admin because of a fatal error in `ping_server`.

```
PHP Fatal error:  Call to a member function ping() on a non-object
```

`get_solr()` return `NULL` until solr server configuration has been done.
So we should check the result value.