### PR TITLE
Limit Travis build branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ branches:
   only:
     - master
     - /^[[:digit:]]+\.[[:digit:]]+.*$/
-    - /^ataylorme.*$/
+    - /^[ataylorme].*$/
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,9 @@ before_script:
   - bash bin/install-solr.sh
 
 script: phpunit
+
+branches:
+  only:
+    - master
+    - /^[[:digit:]]+\.[[:digit:]]+.*$/
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ branches:
   only:
     - master
     - /^[[:digit:]]+\.[[:digit:]]+.*$/
+    - /^ataylorme.*$/
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ branches:
   only:
     - master
     - /^[[:digit:]]+\.[[:digit:]]+.*$/
-    - /^[ataylorme].*$/
+    - /^ataylorme.*$/
     


### PR DESCRIPTION
Only run Travis on the master branch and release versions to eliminate duplicate builds.

Fixes #99.