### PR TITLE
Introduce more WP-CLI commands for Solr Power

### DIFF
--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -128,6 +128,41 @@ class SolrPower_CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Report information about Solr Power configuration.
+	 *
+	 * Displays ping status, alongside Solr server IP address, port, and path.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--field=<field>]
+	 * : Display a specific field.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 */
+	public function info( $args, $assoc_args ) {
+
+		$ping = SolrPower_Api::get_instance()->ping_server();
+		$server = array(
+			'ping_status' => $ping ? 'successful' : 'failed',
+			'ip_address'  => getenv( 'PANTHEON_INDEX_HOST' ),
+			'port'        => getenv( 'PANTHEON_INDEX_PORT' ),
+			'path'        => SolrPower_Api::get_instance()->compute_path(),
+		);
+
+		$formatter = new \WP_CLI\Formatter( $assoc_args, array( 'ping_status', 'ip_address', 'port', 'path' ) );
+		$formatter->display_item( $server );
+	}
+
+	/**
 	 * Optimize the Solr index.
 	 *
 	 * Calls Solarium's addOptimize() to 'defragment' your index. The space

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -147,6 +147,21 @@ class SolrPower_CLI extends WP_CLI_Command {
 	 *   - yaml
 	 *   - csv
 	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp solr info
+	 *     +-------------+------------+
+	 *     | Field       | Value      |
+	 *     +-------------+------------+
+	 *     | ping_status | successful |
+	 *     | ip_address  | localhost  |
+	 *     | port        | 8983       |
+	 *     | path        | /solr      |
+	 *     +-------------+------------+
+	 *
+	 *     $ wp solr info --field=ip_address
+	 *     localhost
 	 */
 	public function info( $args, $assoc_args ) {
 

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -192,6 +192,19 @@ class SolrPower_CLI extends WP_CLI_Command {
 	}
 
 	/**
+	 * Repost schema.xml to Solr.
+	 *
+	 * Deletes the current index, then reposts the schema.xml to Solr.
+	 *
+	 * @subcommand repost-schema
+	 */
+	public function repost_schema() {
+		SolrPower_Sync::get_instance()->delete_all();
+		$output = SolrPower_Api::get_instance()->submit_schema();
+		WP_CLI::success( "Schema reposted: {$output}" );
+	}
+
+	/**
 	 * Report stats about indexed content.
 	 *
 	 * Displays number of indexed posts for each enabled post type.

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -199,6 +199,11 @@ class SolrPower_CLI extends WP_CLI_Command {
 	 * @subcommand repost-schema
 	 */
 	public function repost_schema() {
+
+		if ( ! getenv( 'PANTHEON_ENVIRONMENT' ) || ! getenv( 'FILEMOUNT' ) ) {
+			WP_CLI::error( 'Schema repositing only works in a Pantheon environment.' );
+		}
+
 		SolrPower_Sync::get_instance()->delete_all();
 		$output = SolrPower_Api::get_instance()->submit_schema();
 		WP_CLI::success( "Schema reposted: {$output}" );

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -191,6 +191,47 @@ class SolrPower_CLI extends WP_CLI_Command {
 		WP_CLI::success( 'Index optimized.' );
 	}
 
+	/**
+	 * Report stats about indexed content.
+	 *
+	 * Displays number of indexed posts for each enabled post type.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--field=<field>]
+	 * : Display a specific field.
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format.
+	 * ---
+	 * default: table
+	 * options:
+	 *   - table
+	 *   - json
+	 *   - yaml
+	 *   - csv
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp solr stats
+	 *     +------------+-------+
+	 *     | Field      | Value |
+	 *     +------------+-------+
+	 *     | post       | 2     |
+	 *     | page       | 1     |
+	 *     | attachment | 0     |
+	 *     +------------+-------+
+	 *
+	 *     $ wp solr stats --field=page
+	 *     1
+	 */
+	public function stats( $args, $assoc_args ) {
+		$stats = SolrPower_Api::get_instance()->index_stats();
+		$formatter = new \WP_CLI\Formatter( $assoc_args, array_keys( $stats ) );
+		$formatter->display_item( $stats );
+	}
+
 }
 
 WP_CLI::add_command( 'solr', 'SolrPower_CLI' );


### PR DESCRIPTION
* Refactors `wp solr delete` to accept one or more post ids, or the `--all` flag. Previously, not passing any arguments would cause the index to be deleted, which is an implicit behavior. It's better to have an explicit interface.
* Introduces `wp solr optimize-index` for optimizing the index.
* Introduces `wp solr check-server-settings` which pings the server to see if the connection is valid.
* Adds `wp solr info` and `wp solr stats`, which display tables about server info and index stats, respectively.
* Introduces `wp solr repost-schema` for reposting the schema.xml to the server. Unfortunately, this only works on Pantheon right now (#103)

See #75