### PR TITLE
Update Solr version to `5.5.2`

### DIFF
--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -42,14 +42,11 @@ post_some_documents() {
 download_and_run() {
    
      
-    url="http://archive.apache.org/dist/lucene/solr/3.6.2/apache-solr-3.6.2.tgz"
-    dir_name="apache-solr-3.6.2"
+    url="http://archive.apache.org/dist/lucene/solr/5.5.2/solr-5.5.2.tgz"
+    dir_name="solr-3.6.2"
     dir_conf="conf/"
            
     download $url
-
-    # copy schema.xml
-    cp schema.xml $dir_name/example/solr/$dir_conf
  
     # Run solr
     run $dir_name $SOLR_PORT

--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -41,16 +41,13 @@ post_some_documents() {
 
 download_and_run() {
    
-     
     url="http://archive.apache.org/dist/lucene/solr/5.5.2/solr-5.5.2.tgz"
-    dir_name="solr-3.6.2"
-    dir_conf="conf/"
-           
+    dir_name="solr-5.5.2"
+
     download $url
  
     # Run solr
-    run $dir_name $SOLR_PORT
-
+    run $dir_name/bin/solr -p $SOLR_PORT
 
 }
 

--- a/bin/install-solr.sh
+++ b/bin/install-solr.sh
@@ -22,7 +22,7 @@ wait_for_solr(){
 run() {
     echo "Starting solr on port ${SOLR_PORT}..."
 
-    cd $1/example
+    cd $1/server
     if [ $DEBUG ]
     then
         java -Djetty.port=$SOLR_PORT -jar start.jar &
@@ -47,7 +47,7 @@ download_and_run() {
     download $url
  
     # Run solr
-    run $dir_name/bin/solr -p $SOLR_PORT
+    run $dir_name
 
 }
 


### PR DESCRIPTION
Tests should use the same version of Solr as Pantheon. Solr `5.3` and above don't use a `schema.xml` anymore.