### PR TITLE
Add WP-CLI section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,52 @@ Behat requires a Pantheon site with Solr enabled. Once you've created the site, 
 
 Note that dependencies are installed via Composer and the `vendor` directory is not committed to the repository. You will need to run `composer install` locally for the plugin to function. You can read more about Composer [here](https://getcomposer.org)
 
+## WP-CLI Support ##
+
+This plugin has [WP-CLI](http://wp-cli.org/) support.
+
+All Solr Power related commands are grouped into the `wp solr` command, see an example:
+
+```
+$ wp solr
+usage: wp solr check-server-settings
+   or: wp solr delete [<id>...] [--all]
+   or: wp solr index [--posts_per_page] [--post_type]
+   or: wp solr info [--field=<field>] [--format=<format>]
+   or: wp solr optimize-index
+   or: wp solr repost-schema
+   or: wp solr stats [--field=<field>] [--format=<format>]
+
+See 'wp help solr <command>' for more information on a specific command.
+```
+
+You can see more details about the commands using `wp help solr`:
+
+```
+**NAME**
+
+  wp solr
+
+**DESCRIPTION**
+
+  Perform a variety of actions against your Solr instance.
+
+**SYNOPSIS**
+
+  wp solr <command>
+
+**SUBCOMMANDS**
+
+  check-server-settings      Check server settings.
+  delete                     Remove one or more posts from the index.
+  index                      Index all posts for a site.
+  info                       Report information about Solr Power configuration.
+  optimize-index             Optimize the Solr index.
+  repost-schema              Repost schema.xml to Solr.
+  stats                      Report stats about indexed content.
+
+```
+
 ## Changelog ##
 
 ### 0.5.0 ###

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,52 @@ Behat requires a Pantheon site with Solr enabled. Once you've created the site, 
 
 Note that dependencies are installed via Composer and the `vendor` directory is not committed to the repository. You will need to run `composer install` locally for the plugin to function. You can read more about Composer [here](https://getcomposer.org)
 
+== WP-CLI Support ==
+
+This plugin has [WP-CLI](http://wp-cli.org/) support.
+
+All Solr Power related commands are grouped into the `wp solr` command, see an example:
+
+```
+$ wp solr
+usage: wp solr check-server-settings
+   or: wp solr delete [<id>...] [--all]
+   or: wp solr index [--posts_per_page] [--post_type]
+   or: wp solr info [--field=<field>] [--format=<format>]
+   or: wp solr optimize-index
+   or: wp solr repost-schema
+   or: wp solr stats [--field=<field>] [--format=<format>]
+
+See 'wp help solr <command>' for more information on a specific command.
+```
+
+You can see more details about the commands using `wp help solr`:
+
+```
+**NAME**
+
+  wp solr
+
+**DESCRIPTION**
+
+  Perform a variety of actions against your Solr instance.
+
+**SYNOPSIS**
+
+  wp solr <command>
+
+**SUBCOMMANDS**
+
+  check-server-settings      Check server settings.
+  delete                     Remove one or more posts from the index.
+  index                      Index all posts for a site.
+  info                       Report information about Solr Power configuration.
+  optimize-index             Optimize the Solr index.
+  repost-schema              Repost schema.xml to Solr.
+  stats                      Report stats about indexed content.
+
+```
+
 == Changelog ==
 
 = 0.5.0 =


### PR DESCRIPTION
@danielbachhuber I followed the [WooCommerce example](https://github.com/woothemes/woocommerce/wiki/WP-CLI-commands) with showing the WP-CLI output.

Hopefully this will lead people to using the `help` command going forward rather than referencing the README.

What are your thoughts? Is there a different way you typically document WP-CLI support?