### PR TITLE
Use term_id instead of id. Fixes #153

### DIFF
--- a/includes/class-solrpower-options.php
+++ b/includes/class-solrpower-options.php
@@ -243,6 +243,7 @@ class SolrPower_Options {
 		$options['s4wp_default_operator']       = 'OR';
 		$options['s4wp_default_sort']           = 'score';
 		$options['s4wp_solr_initialized']       = 1;
+		$options['s4wp_index_all_sites']        = 1;
 		$this->update_option( $options );
 	}
 

--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -301,7 +301,7 @@ class SolrPower_Sync {
 				foreach ( $tags as $tag ) {
 					$doc->addField( 'tags', $tag->name );
 					$doc->addField( 'tags_slug_str', $tag->slug );
-					$doc->addField( 'tags_id', $tag->id);
+					$doc->addField( 'tags_id', $tag->term_id);
 					$doc->addField( 'term_taxonomy_id', $tag->term_taxonomy_id );
 				}
 			}

--- a/tests/phpunit/wp_query/test-core-meta.php
+++ b/tests/phpunit/wp_query/test-core-meta.php
@@ -32,6 +32,10 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 
 	}
 
+	function tearDown() {
+		parent::tearDown();
+	}
+
 	public function test_meta_empty() {
 
 		$p1 = self::factory()->post->create();


### PR DESCRIPTION
In the build_document method when tags are being added it improperly referenced ``$tag->id`` instead of ``$tag->term_id``.  This PR corrects that.