### PR TITLE
Allow post_title and post_content to score higher

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -349,6 +349,8 @@ class SolrPower_Api {
 			foreach ( $facet_fields as $facet_field ) {
 				$facetSet->createFacetField( $facet_field )->setField( $facet_field );
 			}
+
+			$dismax->setBoostFunctions('post_title^25 post_content^50');
 			$facetSet->setMinCount( 1 );
 			if ( $facet_on_tags ) {
 				$facetSet->setLimit( $number_of_tags );

--- a/tests/phpunit/class-solr-test-base.php
+++ b/tests/phpunit/class-solr-test-base.php
@@ -35,10 +35,11 @@ class SolrTestBase extends WP_UnitTestCase{
 	}
 
 	function tearDown() {
+
 		parent::tearDown();
 		global $wpdb;
-		$wpdb->query('TRUNCATE ' . $wpdb->posts);
-		$wpdb->query('TRUNCATE ' . $wpdb->postmeta);
+		$wpdb->query( 'TRUNCATE ' . $wpdb->posts );
+		$wpdb->query( 'TRUNCATE ' . $wpdb->postmeta );
 		// Delete the entire index.
 		SolrPower_Sync::get_instance()->delete_all();
 	}
@@ -79,15 +80,20 @@ class SolrTestBase extends WP_UnitTestCase{
 
 
 	/**
-	 * Creates a new post.
+	 * Creates a test post.
+	 *
+	 * @param string $post_type
+	 * @param bool|string $title
+	 * @param bool|string $content
+	 *
 	 * @return int|WP_Error
 	 */
-	function __create_test_post( $post_type = 'post' ) {
+	function __create_test_post( $post_type = 'post', $title = false, $content = false ) {
 		$args = array(
 			'post_type'    => $post_type,
 			'post_status'  => 'publish',
-			'post_title'   => 'Test Post ' . time(),
-			'post_content' => 'This is a solr test.',
+			'post_title'   => ( $title ) ? $title : 'Test Post ' . time(),
+			'post_content' => ( $content ) ? $content : 'This is a solr test.',
 		);
 
 		return wp_insert_post( $args );

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -444,12 +444,26 @@ class SolrTest extends SolrTestBase {
 		wp_set_object_terms( $p_id, $cat_id2, 'category', true );
 
 
-		$p_id2 = $this->__create_test_post( 'post', 'Best Movies of 2015' );
+		$p_id2 = $this->__create_test_post( 'post', 'Best Films of 2015' );
 		wp_set_object_terms( $p_id2, $cat_id, 'category', true );
 
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(
 			's' => 'Movie'
+		);
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( array( $p_id, $p_id2 ), wp_list_pluck( $query->posts, 'ID' ) );
+
+		$args  = array(
+			's' => 'Review'
+		);
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( array( $p_id), wp_list_pluck( $query->posts, 'ID' ) );
+
+		$args  = array(
+			's' => 'Movie Reviews'
 		);
 		$query = new WP_Query( $args );
 

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -401,4 +401,48 @@ class SolrTest extends SolrTestBase {
 		wp_delete_category( $cat_id_two );
 	}
 
+	function test_facets_in_results() {
+		$cat_name = 'Movies';
+		$cat_id   = wp_create_category( $cat_name );
+
+		$p_id = $this->__create_test_post( 'post', 'Casablanca' );
+
+		wp_set_object_terms( $p_id, $cat_id, 'category', true );
+
+		$cat_name = 'Review';
+		$cat_id   = wp_create_category( $cat_name );
+		$p_id2    = $this->__create_test_post( 'post', 'Best Movies of 2015' );
+		wp_set_object_terms( $p_id2, $cat_id, 'category', true );
+
+		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
+		$args  = array(
+			's' => 'Movie'
+		);
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( array( $p_id2, $p_id ), wp_list_pluck( $query->posts, 'ID' ) );
+	}
+
+	function test_facets_in_results_content() {
+		$cat_name = 'Movies';
+		$cat_id   = wp_create_category( $cat_name );
+
+		$p_id = $this->__create_test_post( 'post', 'Casablanca Movie', 'Rated as one of the best movies of all time. This movie is epic.' );
+
+		wp_set_object_terms( $p_id, $cat_id, 'category', true );
+
+		$cat_name = 'Review';
+		$cat_id   = wp_create_category( $cat_name );
+		$p_id2    = $this->__create_test_post( 'post', 'Best Movies of 2015' );
+		wp_set_object_terms( $p_id2, $cat_id, 'category', true );
+
+		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
+		$args  = array(
+			's' => 'Movie'
+		);
+		$query = new WP_Query( $args );
+
+		$this->assertEquals( array( $p_id, $p_id2 ), wp_list_pluck( $query->posts, 'ID' ) );
+	}
+
 }

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -401,6 +401,11 @@ class SolrTest extends SolrTestBase {
 		wp_delete_category( $cat_id_two );
 	}
 
+	/**
+	 * post_title should appear above facets.
+	 * @group 126
+	 * @link https://github.com/pantheon-systems/solr-power/issues/126
+	 */
 	function test_facets_in_results() {
 		$cat_name = 'Movies';
 		$cat_id   = wp_create_category( $cat_name );
@@ -423,17 +428,23 @@ class SolrTest extends SolrTestBase {
 		$this->assertEquals( array( $p_id2, $p_id ), wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
+	/**
+	 * post_title and post_content should appear above facets.
+	 * @group 126
+	 * @link https://github.com/pantheon-systems/solr-power/issues/126
+	 */
 	function test_facets_in_results_content() {
-		$cat_name = 'Movies';
-		$cat_id   = wp_create_category( $cat_name );
+		$cat_name  = 'Movies';
+		$cat_id    = wp_create_category( $cat_name );
+		$cat_name2 = 'Review';
+		$cat_id2   = wp_create_category( $cat_name2 );
 
 		$p_id = $this->__create_test_post( 'post', 'Casablanca Movie', 'Rated as one of the best movies of all time. This movie is epic.' );
 
-		wp_set_object_terms( $p_id, $cat_id, 'category', true );
+		wp_set_object_terms( $p_id, $cat_id2, 'category', true );
 
-		$cat_name = 'Review';
-		$cat_id   = wp_create_category( $cat_name );
-		$p_id2    = $this->__create_test_post( 'post', 'Best Movies of 2015' );
+
+		$p_id2 = $this->__create_test_post( 'post', 'Best Movies of 2015' );
 		wp_set_object_terms( $p_id2, $cat_id, 'category', true );
 
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );


### PR DESCRIPTION
Utilizing a boost function, post_title and post_content can now score higher in results instead of facet items such as taxonomies, custom fields, or categories. This would resolve #126.