### PR TITLE
add some environmental constants

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -112,6 +112,9 @@ class SolrPower_Api {
 	 * @return string
 	 */
 	function compute_path() {
+		if (getenv( 'SOLR_PATH' )) {
+			define('SOLR_PATH', getenv( 'SOLR_PATH' ));
+		}
 		if ( defined( 'SOLR_PATH' ) ) {
 			return SOLR_PATH;
 		}
@@ -157,6 +160,9 @@ class SolrPower_Api {
 		 * Check for the SOLR_POWER_SCHEME constant.
 		 * If it exists and is "http" or "https", use it as the default scheme value.
 		 */
+		if (getenv( 'SOLR_POWER_SCHEME' )) {
+ 			define('SOLR_POWER_SCHEME', getenv( 'SOLR_POWER_SCHEME' ));
+ 		}
 		$default_scheme = ( defined( 'SOLR_POWER_SCHEME' ) && 1 === preg_match( '/^http[s]?$/', SOLR_POWER_SCHEME ) ) ? SOLR_POWER_SCHEME : 'https';
 
 		$solarium_config = array(

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -112,7 +112,7 @@ class SolrPower_Api {
 	 * @return string
 	 */
 	function compute_path() {
-		if (getenv( 'SOLR_PATH' )) {
+		if (!defined('SOLR_PATH') && getenv( 'SOLR_PATH' )) {
 			define('SOLR_PATH', getenv( 'SOLR_PATH' ));
 		}
 		if ( defined( 'SOLR_PATH' ) ) {
@@ -160,7 +160,7 @@ class SolrPower_Api {
 		 * Check for the SOLR_POWER_SCHEME constant.
 		 * If it exists and is "http" or "https", use it as the default scheme value.
 		 */
-		if (getenv( 'SOLR_POWER_SCHEME' )) {
+		if (!defined('SOLR_POWER_SCHEME') && getenv( 'SOLR_POWER_SCHEME' )) {
  			define('SOLR_POWER_SCHEME', getenv( 'SOLR_POWER_SCHEME' ));
  		}
 		$default_scheme = ( defined( 'SOLR_POWER_SCHEME' ) && 1 === preg_match( '/^http[s]?$/', SOLR_POWER_SCHEME ) ) ? SOLR_POWER_SCHEME : 'https';


### PR DESCRIPTION
This is an alternative to adding a mu plugin to set these config variables -- makes local setup a bit easier in my case, where I'm composing a set of docker containers.

e.g., docker-compose.yml:

```yaml
solr:
    image: tehes/solr-4.7.2
    ports:
      - 8983:8080
wordpress:
    image: wordpress
    environment:
        SOLR_PATH: /solr/drupal
        SOLR_POWER_SCHEME: http
        PANTHEON_INDEX_HOST: solr
        PANTHEON_INDEX_PORT: 8080
<snip>
```
