### PR TITLE
Disable Solr functionality if Solr is unavailable

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -127,7 +127,7 @@ class SolrPower_Api {
 	 * @return boolean
 	 */
 	function ping_server() {
-		$solr = get_solr();
+		$solr = $this->get_solr();
 
 		if ( ! $solr ) {
 			return false;

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -127,7 +127,7 @@ class SolrPower_Api {
 	 * @return boolean
 	 */
 	function ping_server() {
-		$solr = $this->get_solr();
+		$solr = SolrPower_Api::get_solr();
 
 		if ( ! $solr ) {
 			return false;

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -154,7 +154,7 @@ class SolrPower_Api {
 	function get_solr() {
 
 		# get the connection options
-		$plugin_s4wp_settings = solr_options();
+		$plugin_s4wp_settings = SolrPower_Options::get_instance()->get_option();
 
 		/*
 		 * Check for the SOLR_POWER_SCHEME constant.
@@ -258,7 +258,7 @@ class SolrPower_Api {
 	 */
 	function query( $qry, $offset, $count, $fq, $sortby, $order, $fields = null ) {
 		//NOTICE: does this needs to be cached to stop the db being hit to grab the options everytime search is being done.
-		$plugin_s4wp_settings = solr_options();
+		$plugin_s4wp_settings = SolrPower_Options::get_instance()->get_option();
 
 		$solr = get_solr();
 

--- a/includes/class-solrpower-facet-widget.php
+++ b/includes/class-solrpower-facet-widget.php
@@ -11,7 +11,13 @@ class SolrPower_Facet_Widget extends WP_Widget {
 			'classname'   => 'solrpower_facet_widget',
 			'description' => 'Facet your search results.',
 		);
-		parent::__construct( 'solrpower_facet_widget', 'Solr Search', $widget_ops );
+		/**
+		 * Only register the Solr search widget if Solr is available.
+		 */
+		$retval = SolrPower_Api::get_instance()->ping_server();
+		if ( $retval ) {
+			parent::__construct( 'solrpower_facet_widget', 'Solr Search', $widget_ops );
+		}
 	}
 
 	/**

--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -27,6 +27,13 @@ class SolrPower_Sync {
 	}
 
 	function __construct() {
+		/**
+		 * Only register the Solr sync actions if Solr is available.
+		 */
+		$retval = SolrPower_Api::get_instance()->ping_server();
+		if ( ! $retval ) {
+			return;
+		}
 		add_action( 'publish_post', array( $this, 'handle_modified' ) );
 		add_action( 'publish_page', array( $this, 'handle_modified' ) );
 		add_action( 'save_post', array( $this, 'handle_modified' ) );

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -85,6 +85,13 @@ class SolrPower_WP_Query {
 			return;
 		}
 
+		/**
+		 * Only enable Solr for WP_Query if Solr is available.
+		 */
+		$retval = SolrPower_Api::get_instance()->ping_server();
+		if ( ! $retval ) {
+			return;
+		}
 
 		add_filter( 'posts_request', array( $this, 'posts_request' ), 10, 2 );
 

--- a/includes/class-solrpower.php
+++ b/includes/class-solrpower.php
@@ -27,9 +27,15 @@ class SolrPower {
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_scripts' ) );
 		add_filter( 'plugin_action_links', array( $this, 'plugin_settings_link' ), 10, 2 );
 		add_filter( 'debug_bar_panels', array( $this, 'add_panel' ) );
-		add_action( 'widgets_init', function () {
-			register_widget( 'SolrPower_Facet_Widget' );
-		} );
+		/**
+		 * Only register the Solr search widget if Solr is available.
+		 */
+		$retval = SolrPower_Api::get_instance()->ping_server();
+		if ( $retval ) {
+			add_action( 'widgets_init', function () {
+				register_widget( 'SolrPower_Facet_Widget' );
+			} );
+		}
 	}
 
 	function activate() {

--- a/includes/class-solrpower.php
+++ b/includes/class-solrpower.php
@@ -27,15 +27,9 @@ class SolrPower {
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_scripts' ) );
 		add_filter( 'plugin_action_links', array( $this, 'plugin_settings_link' ), 10, 2 );
 		add_filter( 'debug_bar_panels', array( $this, 'add_panel' ) );
-		/**
-		 * Only register the Solr search widget if Solr is available.
-		 */
-		$retval = SolrPower_Api::get_instance()->ping_server();
-		if ( $retval ) {
-			add_action( 'widgets_init', function () {
-				register_widget( 'SolrPower_Facet_Widget' );
-			} );
-		}
+		add_action( 'widgets_init', function () {
+			register_widget( 'SolrPower_Facet_Widget' );
+		} );
 	}
 
 	function activate() {


### PR DESCRIPTION
* Fallback to WP_Query if Solr isn't available
* Don't register Solr search widget if Solr isn't available
* Don't add post modified options if Solr isn't available
* Addresses #139