### PR TITLE
Falls back to default WP_Query if Solr is not available.

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -27,6 +27,11 @@ class SolrPower_Api {
 	public $last_error;
 
 	/**
+	 * @var bool Ping results from Solr.
+	 */
+	public $ping = false;
+
+	/**
 	 * Grab instance of object.
 	 * @return SolrPower_Api
 	 */
@@ -40,6 +45,7 @@ class SolrPower_Api {
 
 	function __construct() {
 		add_action( 'admin_notices', array( $this, 'check_for_schema' ) );
+		add_action( 'init', array( $this, 'ping_server' ) );
 	}
 
 	function submit_schema() {
@@ -136,7 +142,7 @@ class SolrPower_Api {
 		try {
 			$ping            = $solr->ping( $solr->createPing() );
 			$this->last_code = 200;
-
+			$this->ping = true;
 			return true;
 		} catch ( Solarium\Exception\HttpException $e ) {
 

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -109,7 +109,9 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function posts_request( $request, $query ) {
-		if ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) ) {
+		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
+		     || false === SolrPower_Api::get_instance()->ping
+		) {
 			return $request;
 		}
 		add_filter( 'solr_query', array( SolrPower_Api::get_instance(), 'dismax_query' ), 10, 2 );
@@ -327,7 +329,7 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function found_posts_query( $sql, $query ) {
-		if ( ! $query->is_search() ) {
+		if ( ! $query->is_search() || false === SolrPower_Api::get_instance()->ping ) {
 			return $sql;
 		}
 

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -140,4 +140,24 @@ class SolrWPQueryTest extends SolrTestBase {
 		$this->assertEquals( 2, $query->found_posts );
 	}
 
+	function test_wp_query_failed_ping() {
+		$this->__create_test_post();
+		$args  = array(
+			's' => 'solr'
+		);
+		SolrPower_Api::get_instance()->ping=false;
+		$query = new WP_Query( $args );
+		$this->assertEquals( $query->post_count, 1 );
+		$this->assertEquals( $query->found_posts, 1 );
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			global $post;
+
+			$this->assertFalse( isset($post->solr) );
+		}
+
+		wp_reset_postdata();
+		SolrPower_Api::get_instance()->ping=true;
+	}
 }


### PR DESCRIPTION
Performs a ping at init and checks ping results when WP_Query is used.

Fixes #139