### PR TITLE
Add post types and status filters

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -64,7 +64,7 @@ class SolrPower_Api {
 		}
 
 		$path        = $this->compute_path();
-		$url         = $this->get_default_scheme() . '://' . getenv( 'PANTHEON_INDEX_HOST' ) . ':' . getenv( 'PANTHEON_INDEX_PORT' ) . '/' . $path;
+		$url         = $this->get_default_scheme() . '://' . getenv( 'PANTHEON_INDEX_HOST' ) . ':' . getenv( 'PANTHEON_INDEX_PORT' ) . $path;
 		$client_cert = realpath( ABSPATH . '../certs/binding.pem' );
 
 		/*
@@ -87,7 +87,7 @@ class SolrPower_Api {
 		// set URL and other appropriate options
 		$opts = array(
 			CURLOPT_URL            => $url,
-			CURLOPT_PORT           => 449,
+			CURLOPT_PORT           => getenv( 'PANTHEON_INDEX_PORT' ),
 			CURLOPT_RETURNTRANSFER => 1,
 			CURLOPT_SSLCERT        => $client_cert,
 			CURLOPT_SSL_VERIFYPEER => false,
@@ -432,7 +432,7 @@ class SolrPower_Api {
 		$stats     = wp_cache_get( $cache_key, 'solr' );
 		if ( false === $stats ) {
 
-			$post_types = get_post_types( array( 'exclude_from_search' => false ) );
+			$post_types = apply_filters('solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) );
 
 			$stats = array();
 			foreach ( $post_types as $type ) {

--- a/includes/class-solrpower-batch-index.php
+++ b/includes/class-solrpower-batch-index.php
@@ -73,7 +73,7 @@ class SolrPower_Batch_Index {
 	 */
 	public function __construct( $query_args = array() ) {
 		$defaults = array(
-			'post_status'     => 'publish',
+			'post_status'     => apply_filters( 'solr_post_status', ['publish'] ),
 			'post_type'       => apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) ),
 			'posts_per_page'  => 100,
 		);

--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -54,7 +54,8 @@ class SolrPower_Sync {
 		}
 
 		$this->handle_status_change( $post_id, $post_info );
-		if ( $post_info->post_type == 'revision' || $post_info->post_status != 'publish' ) {
+		$post_status = apply_filters( 'solr_post_status', ['publish'] );
+		if ( $post_info->post_type == 'revision' || !in_array( $post_info->post_status, $post_status, true ) ) {
 			return;
 		}
 		# make sure this blog is not private or a spam if indexing on a multisite install
@@ -492,7 +493,7 @@ class SolrPower_Sync {
 					 * @param array $post_types Array of post type names for indexing.
 					 */
 					'post_type'      => apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) ),
-					'post_status'    => 'publish',
+					'post_status'    => apply_filters( 'solr_post_status', ['publish'] ),
 					'fields'         => 'ids',
 					'posts_per_page' => absint( $limit ),
 					'offset'         => absint( $prev )
@@ -556,7 +557,7 @@ class SolrPower_Sync {
 				 * @param array $post_types Array of post type names for indexing.
 				 */
 				'post_type'      => apply_filters( 'solr_post_types', get_post_types( array( 'exclude_from_search' => false ) ) ),
-				'post_status'    => 'publish',
+				'post_status'    => apply_filters( 'solr_post_status', ['publish'] ),
 				'fields'         => 'ids',
 				'posts_per_page' => absint( $limit ),
 				'offset'         => absint( $prev )

--- a/views/options/info.php
+++ b/views/options/info.php
@@ -16,7 +16,7 @@
                 </li>
                 <li>
                     <strong>Solr Server Port:</strong>
-					<?php echo esc_html( getenv( $server_info['port'] ) ); ?>
+					<?php echo esc_html( $server_info['port'] ); ?>
                 </li>
                 <li>
                     <strong>Solr Server Path:</strong>


### PR DESCRIPTION
- Add the ability to use post type filter to include other post types 
- Add the ability to use post status filter since, if you are using admin search, you can't index/search in other post status 
- Use PANTHEON_INDEX_PORT instead hardcoded port on curl
- Fix solr port display in settings page