### PR TITLE
Respect all query vars when searching with WP_Query

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -417,8 +417,8 @@ class SolrPower_WP_Query {
 			'page_id' => 'ID',
 			'name'    => 'post_name'
 		);
-		if ( ! $query->get( 'solr_integrate' ) ) {
-			return $query->get( 's' );
+		if ( ! $query->get( 's' ) && ! $query->get( 'solr_integrate' ) ) {
+			return '';
 		}
 
 		$solr_query = array();

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -160,4 +160,16 @@ class SolrWPQueryTest extends SolrTestBase {
 		wp_reset_postdata();
 		SolrPower_Api::get_instance()->ping=true;
 	}
+
+	public function test_wp_query_search_filter_post_type() {
+		$post_id = $this->__create_test_post();
+		$page_id = $this->__create_test_post( 'page' );
+		$args = array(
+			's'         => 'Test',
+			'post_type' => 'page',
+		);
+		$query = new WP_Query( $args );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
+	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -162,8 +162,8 @@ class SolrWPQueryTest extends SolrTestBase {
 	}
 
 	public function test_wp_query_search_filter_post_type() {
-		$post_id = $this->__create_test_post();
-		$page_id = $this->__create_test_post( 'page' );
+		$post_id = $this->__create_test_post(); // Title defaults to 'Test Post'
+		$page_id = $this->__create_test_post( 'page' ); // Title defaults to 'Test Post'
 		$args = array(
 			's'         => 'Test',
 			'post_type' => 'page',
@@ -171,5 +171,7 @@ class SolrWPQueryTest extends SolrTestBase {
 		$query = new WP_Query( $args );
 		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( 'page', $query->get('post_type') );
+		$this->assertEquals( array( $page_id ), wp_list_pluck( $query->posts, 'ID' ) );
 	}
 }


### PR DESCRIPTION
The prior behavior would bail early when `s` was set but
`solr_integrate` wasn't provided, which meant query vars would be
discarded when searching

Fixes #244