### PR TITLE
Add missing filter for custom fields

### DIFF
--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -214,16 +214,14 @@ class SolrPower_Sync {
 		$exclude_ids            = ( is_array( $plugin_s4wp_settings['s4wp_exclude_pages'] ) ) ? $plugin_s4wp_settings['s4wp_exclude_pages'] : explode( ',', $plugin_s4wp_settings['s4wp_exclude_pages'] );
 		$categoy_as_taxonomy    = $plugin_s4wp_settings['s4wp_cat_as_taxo'];
 		$index_comments         = $plugin_s4wp_settings['s4wp_index_comments'];
-		$facet_on_custom_fields = $plugin_s4wp_settings['s4wp_index_custom_fields'];
 		/**
 		 * Filter indexed custom fields
 		 *
 		 * Filter the list of custom field slugs available to index.
 		 *
-		 * @param array $facet_on_custom_fields Array of custom field slugs for indexing.
+		 * @param array $index_custom_fields Array of custom field slugs for indexing.
 		 */
-		$plugin_s4wp_settings['s4wp_index_custom_fields'] = apply_filters( 'solr_index_custom_fields', $facet_on_custom_fields );
-		$index_custom_fields                              = ( is_array( $plugin_s4wp_settings['s4wp_index_custom_fields'] ) ) ? $plugin_s4wp_settings['s4wp_index_custom_fields'] : explode( ',', $plugin_s4wp_settings['s4wp_index_custom_fields'] );
+		$index_custom_fields 	= apply_filters( 'solr_index_custom_fields', $plugin_s4wp_settings['s4wp_index_custom_fields'] );
 
 		if ( $post_info ) {
 


### PR DESCRIPTION
Custom fields are not being included in search query, also part of the code was replaced in solrpower sync file since the `s4wp_index_custom_fields` options is parsed as an array when options are being loaded and it will just validate that the value is an array before using it.

Fixes and improvements
- Add missing filter for custom fields when searching
- Add custom fields validation when parsing meta query