### PR TITLE
Use `sort=query()` to boost posts with matching titles to the top of results

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -172,7 +172,7 @@ class SolrPower_WP_Query {
 		} else {
 			// Boost partial match on post_title to simulate WordPress' use of MySQL ORDER BY CASE.
 			if ( $query->get( 's' ) ) {
-				$extra['sort_before'][ "query({!dismax qf=post_title v='" . $query->get( 's' ) . "'})" ] = 'desc';
+				$extra['sort_before'][ "query({!dismax qf=post_title v='\"" . $query->get( 's' ) . "\"'})" ] = 'desc';
 			}
 		}
 

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -155,6 +155,7 @@ class SolrPower_WP_Query {
 		$fq        = $this->parse_facets( $query );
 		$sortby    = ( isset( $solr_options['s4wp_default_sort'] ) && ! empty( $solr_options['s4wp_default_sort'] ) ) ? $solr_options['s4wp_default_sort'] : 'score';
 		$order     = ( $query->get( 'order', false ) ) ? strtolower( $query->get( 'order' ) ) : 'desc';
+		$extra     = array();
 		if ( $query->get( 'orderby', false ) ) {
 			$orderby = $query->get( 'orderby' );
 
@@ -167,6 +168,11 @@ class SolrPower_WP_Query {
 				$order  = false;
 			} else {
 				$sortby = $this->parse_orderby( $orderby, $query );
+			}
+		} else {
+			// Boost partial match on post_title to simulate WordPress' use of MySQL ORDER BY CASE.
+			if ( $query->get( 's' ) ) {
+				$extra['sort_before'][ "query({!dismax qf=post_title v='" . $query->get( 's' ) . "'})" ] = 'desc';
 			}
 		}
 
@@ -181,7 +187,7 @@ class SolrPower_WP_Query {
 		}
 		$query->set( 'fields', '' );
 		unset( $query->query['fields'] );
-		$search = SolrPower_Api::get_instance()->query( $qry, $offset, $count, $fq, $sortby, $order, $fields );
+		$search = SolrPower_Api::get_instance()->query( $qry, $offset, $count, $fq, $sortby, $order, $fields, $extra );
 
 		if ( is_null( $search ) ) {
 			return false;

--- a/tests/phpunit/wp_query/test-search-relevance.php
+++ b/tests/phpunit/wp_query/test-search-relevance.php
@@ -1,0 +1,22 @@
+<?php
+
+class SolrSearchRelevanceTest extends SolrTestBase {
+
+	function test_search_order_title_exact_match_most_relevant() {
+		foreach ( range( 1, 7 ) as $i ) {
+			self::factory()->post->create( array(
+				'post_title'   => $i . ' ' . rand_str(),
+				'post_content' => 'Star Wars Star Wars ' . $i . rand_str() . ' Star Wars Star Wars Star Wars Star Wars Star Wars Star Wars Star Wars',
+				'post_type'    => 'post',
+			) );
+		}
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Star Wars', 'post_type' => 'post' ) );
+		$query = new WP_Query( array(
+			's'         => 'Star Wars',
+			'post_type' => 'post',
+		) );
+		$posts = $query->posts;
+		$this->assertEquals( $post_id, reset( $posts )->ID );
+	}
+
+}


### PR DESCRIPTION
Fixes #270