### PR TITLE
Introduce `batch-size` argument for `wp solr index`

### DIFF
--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -78,7 +78,7 @@ class SolrPower_CLI extends WP_CLI_Command {
 	 * [--batch=<batch>]
 	 * : Start indexing at a specific batch. Defaults to last indexed batch, or very beginning.
 	 *
-	 * [--batch-size=<size>]
+	 * [--batch_size=<size>]
 	 * : Number of posts per batch.
 	 * ---
 	 * default: 100
@@ -96,8 +96,8 @@ class SolrPower_CLI extends WP_CLI_Command {
 		if ( isset( $assoc_args['batch'] ) ) {
 			$query_args['batch'] = (int) $assoc_args['batch'];
 		}
-		if ( isset( $assoc_args['batch-size'] ) ) {
-			$query_args['posts_per_page'] = (int) $assoc_args['posts_per_page'];
+		if ( isset( $assoc_args['batch_size'] ) ) {
+			$query_args['posts_per_page'] = (int) $assoc_args['batch_size'];
 		}
 
 		$batch_index = new SolrPower_Batch_Index( $query_args );

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -78,6 +78,9 @@ class SolrPower_CLI extends WP_CLI_Command {
 	 * [--batch=<batch>]
 	 * : Start indexing at a specific batch. Defaults to last indexed batch, or very beginning.
 	 *
+	 * [--batch-size=<size>]
+	 * : Number of posts per batch. Defaults to 100.
+	 *
 	 * [--post_type=<post-type>]
 	 * : Limit indexing to a specific post type. Defaults to all searchable.
 	 */
@@ -89,6 +92,9 @@ class SolrPower_CLI extends WP_CLI_Command {
 		}
 		if ( isset( $assoc_args['batch'] ) ) {
 			$query_args['batch'] = (int) $assoc_args['batch'];
+		}
+		if ( isset( $assoc_args['batch-size'] ) ) {
+			$query_args['posts_per_page'] = (int) $assoc_args['posts_per_page'];
 		}
 
 		$batch_index = new SolrPower_Batch_Index( $query_args );

--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -79,7 +79,10 @@ class SolrPower_CLI extends WP_CLI_Command {
 	 * : Start indexing at a specific batch. Defaults to last indexed batch, or very beginning.
 	 *
 	 * [--batch-size=<size>]
-	 * : Number of posts per batch. Defaults to 100.
+	 * : Number of posts per batch.
+	 * ---
+	 * default: 100
+	 * ---
 	 *
 	 * [--post_type=<post-type>]
 	 * : Limit indexing to a specific post type. Defaults to all searchable.


### PR DESCRIPTION
`--batch-size=<size>` limits the number of posts per batch to `<size>`.

Fixes #338.