### PR TITLE
Remove unnecessary reference sign from `SolrPower_WP_Query::the_posts()`

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -379,7 +379,7 @@ class SolrPower_WP_Query {
 	 *
 	 * @return mixed
 	 */
-	function the_posts( $posts, &$query ) {
+	function the_posts( $posts, $query ) {
 		if ( ! isset( $this->found_posts[ spl_object_hash( $query ) ] ) ) {
 			return $posts;
 		}


### PR DESCRIPTION
Prevents a PHP warning for `Parameter 2 to SolrPower_WP_Query::the_posts() expected to be a reference, value given`.

Fixes #341.