### PR TITLE
Error early when there are no posts to index

### DIFF
--- a/includes/class-solrpower-cli.php
+++ b/includes/class-solrpower-cli.php
@@ -100,7 +100,10 @@ class SolrPower_CLI extends WP_CLI_Command {
 			$query_args['posts_per_page'] = (int) $assoc_args['batch_size'];
 		}
 
-		$batch_index     = new SolrPower_Batch_Index( $query_args );
+		$batch_index = new SolrPower_Batch_Index( $query_args );
+		if ( ! $batch_index->have_posts() ) {
+			WP_CLI::error( 'No posts found.' );
+		}
 		$displayed_batch = false;
 		$start_time      = microtime( true );
 		while ( $batch_index->have_posts() ) {


### PR DESCRIPTION
Fixes #345

```
$ wp solr index --batch=1000
Error: No posts found.
$ wp solr index --batch=2
Starting batch 2 of 54 at 0:00:00 elapsed time (0 indexed, 0 failed, 5295 remaining)
```