### PR TITLE
Added post__in and post__not_in support

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -115,6 +115,9 @@ class SolrPower_WP_Query {
 
 		add_filter( 'posts_request', array( $this, 'posts_request' ), 10, 2 );
 
+		// Adjusts for NOT queries
+		add_filter( 'solr_select_query', array( $this, 'solr_select_query' ), 10, 1 ); 
+
 		// Nukes the FOUND_ROWS() database query.
 		add_filter( 'found_posts_query', array( $this, 'found_posts_query' ), 5, 2 );
 
@@ -358,6 +361,19 @@ class SolrPower_WP_Query {
 	}
 
 	/**
+	 * Adjusts the solr select query syntax.
+	 * 
+	 * @param string	$select		Select query
+	 * 
+	 * @return string
+	 */
+	function solr_select_query( $select ) { 
+		$select['query'] = str_replace( '(!', '!(', $select['query'] ); 
+		
+		return $select; 
+	}
+
+	/**
 	 * Overload the found posts query.
 	 *
 	 * @param string   $sql   Original SQL string.
@@ -447,13 +463,16 @@ class SolrPower_WP_Query {
 			'page_id',
 			'post_status',
 			'post_parent',
+			'post__in',
+			'post__not_in',
 			'name',
-
 		);
 		$convert = array(
-			'p'       => 'ID',
-			'page_id' => 'ID',
-			'name'    => 'post_name',
+			'p'       	=> 'ID',
+			'page_id' 	=> 'ID',
+			'post__in'	=> 'ID',
+			'post__not_in'	=> '!ID',
+			'name'    	=> 'post_name',
 		);
 		if ( ! $query->get( 's' ) && ! $query->get( 'solr_integrate' ) ) {
 			return '';

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -368,8 +368,8 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function solr_select_query( $select ) {
-		// Replace all occurrences of (! with !(.
-		$select['query'] = str_replace( '(!', '!(', $select['query'] );
+		// Correcting whitelist NOT query conversion to proper solr syntax.
+		$select['query'] = str_replace( '(!ID', '!(ID', $select['query'] );
 		return $select;
 	}
 

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -370,6 +370,7 @@ class SolrPower_WP_Query {
 	function solr_select_query( $select ) {
 		// Correcting whitelist NOT query conversion to proper solr syntax.
 		$select['query'] = str_replace( '(!ID', '!(ID', $select['query'] );
+
 		return $select;
 	}
 

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -469,11 +469,11 @@ class SolrPower_WP_Query {
 			'name',
 		);
 		$convert     = array(
-			'p'       	   => 'ID',
-			'page_id' 	   => 'ID',
-			'post__in'	   => 'ID',
+			'p'            => 'ID',
+			'page_id'      => 'ID',
+			'post__in'     => 'ID',
 			'post__not_in' => '!ID',
-			'name'    	   => 'post_name',
+			'name'         => 'post_name',
 		);
 		if ( ! $query->get( 's' ) && ! $query->get( 'solr_integrate' ) ) {
 			return '';

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -115,8 +115,8 @@ class SolrPower_WP_Query {
 
 		add_filter( 'posts_request', array( $this, 'posts_request' ), 10, 2 );
 
-		// Adjusts for NOT queries
-		add_filter( 'solr_select_query', array( $this, 'solr_select_query' ), 10, 1 ); 
+		// Adjusts for NOT queries.
+		add_filter( 'solr_select_query', array( $this, 'solr_select_query' ), 10, 1 );
 
 		// Nukes the FOUND_ROWS() database query.
 		add_filter( 'found_posts_query', array( $this, 'found_posts_query' ), 5, 2 );
@@ -362,15 +362,15 @@ class SolrPower_WP_Query {
 
 	/**
 	 * Adjusts the solr select query syntax.
-	 * 
-	 * @param string	$select		Select query
-	 * 
+	 *
+	 * @param string $select		Select query.
+	 *
 	 * @return string
 	 */
-	function solr_select_query( $select ) { 
-		$select['query'] = str_replace( '(!', '!(', $select['query'] ); 
-		
-		return $select; 
+	function solr_select_query( $select ) {
+		// Replace all occurrences of (! with !(.
+		$select['query'] = str_replace( '(!', '!(', $select['query'] );
+		return $select;
 	}
 
 	/**
@@ -467,12 +467,12 @@ class SolrPower_WP_Query {
 			'post__not_in',
 			'name',
 		);
-		$convert = array(
-			'p'       	=> 'ID',
-			'page_id' 	=> 'ID',
-			'post__in'	=> 'ID',
-			'post__not_in'	=> '!ID',
-			'name'    	=> 'post_name',
+		$convert     = array(
+			'p'       	   => 'ID',
+			'page_id' 	   => 'ID',
+			'post__in'	   => 'ID',
+			'post__not_in' => '!ID',
+			'name'    	   => 'post_name',
 		);
 		if ( ! $query->get( 's' ) && ! $query->get( 'solr_integrate' ) ) {
 			return '';

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -193,7 +193,7 @@ class SolrWPQueryTest extends SolrTestBase {
 		$this->assertEquals( $post_id, $query->post->ID );
 	}
 
-	public function test_wp_query_by_post__not_in_arr() {
+	public function test_wp_query_by_post__not_in() {
 		$post_id = $this->__create_test_post();
 		$post_id2 = $this->__create_test_post();
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
@@ -202,7 +202,7 @@ class SolrWPQueryTest extends SolrTestBase {
 			'post__not_in'   => array( $post_id ),
 		);
 		$query = new WP_Query( $args );
-		$this->assertEquals( 1, $query->found_posts );
+		$this->assertEquals( 1, $query->post_count );
 		$this->assertEquals( $post_id2, $query->post->ID );
 	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -181,6 +181,7 @@ class SolrWPQueryTest extends SolrTestBase {
 
 	public function test_wp_query_by_post__in() {
 		$post_id = $this->__create_test_post();
+		$post_id2 = $this->__create_test_post();
 		$page_id = $this->__create_test_post( 'page' );
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -178,4 +178,28 @@ class SolrWPQueryTest extends SolrTestBase {
 		$this->assertEquals( 'page', $query->get('post_type') );
 		$this->assertEquals( array( $page_id ), wp_list_pluck( $query->posts, 'ID' ) );
 	}
+
+	public function test_wp_query_by_post__in() {
+		$post_id = $this->__create_test_post();
+		$page_id = $this->__create_test_post( 'page' );
+		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
+		$args  = array(
+			'solr_integrate' => true,
+			'post__in'       => array( $post_id ),
+		);
+		$query = new WP_Query( $args );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( $post_id, $query->post->ID );
+	}
+
+	public function test_wp_query_by_post__not_in_arr() {
+		$post_id = $this->__create_test_post();
+		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
+		$args  = array(
+			'solr_integrate' => true,
+			'post__not_in'   => array( $post_id ),
+		);
+		$query = new WP_Query( $args );
+		$this->assertEquals( 0, $query->post_count );
+	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -195,13 +195,17 @@ class SolrWPQueryTest extends SolrTestBase {
 	public function test_wp_query_by_post__not_in() {
 		$post_id = $this->__create_test_post();
 		$post_id2 = $this->__create_test_post();
+		$post_id3 = $this->__create_test_post();
+		$post_id4 = $this->__create_test_post();
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(
 			'solr_integrate' => true,
-			'post__not_in'   => array( $post_id ),
+			'post__not_in'   => array( $post_id, $post_id3 ),
 		);
 		$query = new WP_Query( $args );
-		$this->assertEquals( 1, $query->post_count );
-		$this->assertEquals( $post_id2, $query->post->ID );
+		$this->assertEquals( 2, $query->post_count );
+		$ids = wp_list_pluck( $query->posts, 'ID' );
+		sort( $ids );
+		$this->assertEquals( array( $post_id2, $post_id4 ), $ids );
 	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -185,11 +185,11 @@ class SolrWPQueryTest extends SolrTestBase {
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(
 			'solr_integrate' => true,
-			'post__in'       => array( $post_id ),
+			'post__in'       => array( $post_id2 ),
 		);
 		$query = new WP_Query( $args );
 		$this->assertEquals( 1, $query->post_count );
-		$this->assertEquals( $post_id, $query->post->ID );
+		$this->assertEquals( $post_id2, $query->posts[0]->ID );
 	}
 
 	public function test_wp_query_by_post__not_in() {

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -202,7 +202,7 @@ class SolrWPQueryTest extends SolrTestBase {
 			'post__not_in'   => array( $post_id ),
 		);
 		$query = new WP_Query( $args );
-		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( 1, $query->found_posts );
 		$this->assertEquals( $post_id2, $query->post->ID );
 	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -195,12 +195,14 @@ class SolrWPQueryTest extends SolrTestBase {
 
 	public function test_wp_query_by_post__not_in_arr() {
 		$post_id = $this->__create_test_post();
+		$post_id2 = $this->__create_test_post();
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(
 			'solr_integrate' => true,
 			'post__not_in'   => array( $post_id ),
 		);
 		$query = new WP_Query( $args );
-		$this->assertEquals( 0, $query->post_count );
+		$this->assertEquals( 1, $query->post_count );
+		$this->assertEquals( $post_id2, $query->post->ID );
 	}
 }

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -182,7 +182,6 @@ class SolrWPQueryTest extends SolrTestBase {
 	public function test_wp_query_by_post__in() {
 		$post_id = $this->__create_test_post();
 		$post_id2 = $this->__create_test_post();
-		$page_id = $this->__create_test_post( 'page' );
 		SolrPower_Sync::get_instance()->load_all_posts( 0, 'post', 100, false );
 		$args  = array(
 			'solr_integrate' => true,


### PR DESCRIPTION
Added in missing `post__in` and `post__not_in` WP_Query args using the approach described by @rdanamcd. However, I generalized the approach to account for other possible NOT queries and formatted code to meet project's code standards.

Cases That Should Now Work:
1. WP_Query with post_in arg (will work with array lengths of 1 or more)
2. WP_Query with post__not_in arg (will work with array lengths of 1 or more)