### PR TITLE
Ensure `$post->post_author` remains user ID when processing WP_Query

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -248,6 +248,11 @@ class SolrPower_WP_Query {
 					continue;
 				}
 
+				if ( 'post_author' === $key ) {
+					$post->post_author = get_post_field( 'post_author', $post_array['ID'], 'db' );
+					continue;
+				}
+
 				if ( 'post_id' === $key ) {
 					$post->ID = $value;
 					continue;

--- a/tests/phpunit/class-solr-test-base.php
+++ b/tests/phpunit/class-solr-test-base.php
@@ -103,6 +103,7 @@ class SolrTestBase extends WP_UnitTestCase{
 		$args = array(
 			'post_type'    => $post_type,
 			'post_status'  => 'publish',
+			'post_author'  => 1,
 			'post_title'   => ( $title ) ? $title : 'Test Post ' . time(),
 			'post_content' => ( $content ) ? $content : 'This is a solr test.',
 		);

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -48,7 +48,8 @@ class SolrTest extends SolrTestBase {
 		$search = $search->getData();
 		$search = $search['response'];
 
-		$this->assertEquals( $search['docs'][0]['ID'], $post_id );
+		$this->assertEquals( $post_id, $search['docs'][0]['ID'] );
+		$this->assertEquals( 'admin', $search['docs'][0]['post_author'] );
 	}
 
 	/**

--- a/tests/phpunit/wp_query/test-wp-query.php
+++ b/tests/phpunit/wp_query/test-wp-query.php
@@ -23,8 +23,9 @@ class SolrWPQueryTest extends SolrTestBase {
 			global $post;
 
 			$wp_post = get_post( get_the_ID() );
-			$this->assertEquals( $post->solr, true );
+			$this->assertTrue( $post->solr );
 			$this->assertEquals( $post->post_title, get_the_title() );
+			$this->assertEquals( $post->post_author, 1 );
 			$this->assertEquals( $post->post_content, get_the_content() );
 			$this->assertEquals( $post->post_date, $wp_post->post_date );
 			$this->assertEquals( $post->post_modified, $wp_post->post_modified );


### PR DESCRIPTION
Fixes #353