### PR TITLE
Tab in the readme.txt code block

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -50,17 +50,15 @@ Alternatively, there are a couple of community-maintained Docker containers you 
 
 In a local development environment, you can point Solr Power to a custom Solr instance by creating a MU plugin with:
 
-```
-<?php
-/**
- * Define Solr host IP, port, scheme and path
- * Update these as necessary if your configuration differs
-*/
-putenv( 'PANTHEON_INDEX_HOST=192.168.50.4' );
-putenv( 'PANTHEON_INDEX_PORT=8983' );
-add_filter( 'solr_scheme', function(){ return 'http'; });
-define( 'SOLR_PATH', '/solr/wordpress/' );
-```
+    <?php
+    /**
+     * Define Solr host IP, port, scheme and path
+     * Update these as necessary if your configuration differs
+     */
+    putenv( 'PANTHEON_INDEX_HOST=192.168.50.4' );
+    putenv( 'PANTHEON_INDEX_PORT=8983' );
+    add_filter( 'solr_scheme', function(){ return 'http'; });
+    define( 'SOLR_PATH', '/solr/wordpress/' );
 
 == Development ==
 


### PR DESCRIPTION
Minor formatting change: tabs in one of the code blocks instead of using triple backticks, so that things render nicely [over here](https://wordpress.org/plugins/solr-power/#installation) :-)