### PR TITLE
added support for changing post excerpt to highlighted snippet 

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -60,6 +60,13 @@ class SolrPower_WP_Query {
 	public $query;
 
 	/**
+	 * Highlighted field snippets
+	 *
+	 * @var array
+	 */
+	public $highlighting;
+
+	/**
 	 * Grab instance of object.
 	 *
 	 * @return SolrPower_WP_Query
@@ -199,7 +206,10 @@ class SolrPower_WP_Query {
 		if ( $search->getFacetSet() ) {
 			$this->facets = $search->getFacetSet()->getFacets();
 		}
-		$search = $search->getData();
+
+    $this->highlighting = $search->getHighlighting();
+		
+    $search = $search->getData();
 
 		$search_header        = $search['responseHeader'];
 		$search               = $search['response'];
@@ -257,6 +267,23 @@ class SolrPower_WP_Query {
 					$post->ID = $value;
 					continue;
 				}
+
+        if ( 'solr_id' === $key ) {
+          if ( $this->highlighting ) {
+            $highlighted_doc = $this->highlighting->getResult($value);
+
+            if ( $highlighted_doc ) {
+              $snippet = '';
+
+              foreach ( $highlighted_doc as $field => $highlight ) {
+                $snippet .= implode(' ... ', $highlight);
+              }
+
+              $post->excerpt = $snippet;
+              continue;
+            }
+          }
+        }
 
 				$post->$key = $value;
 			}


### PR DESCRIPTION
Highlighting is enabled in the solr query but it didn't look like it was ever making it back to the post object for use in the search result. This patch brings the highlighted snippet into the $post->excerpt. 