### PR TITLE
Use posts_pre_query hook to support fields queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
 **Tested up to:** 5.4  
-**Stable tag:** 2.1.4  
+**Stable tag:** 2.2.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -163,6 +163,9 @@ To support searching by author name (e.g. where "Pantheon" would return posts au
 ```
 
 ## Changelog ##
+
+### 2.2.0 (May 5, 2020) ###
+* Uses `posts_pre_query` hook to support use of 'fields' in `WP_Query` [[#448](https://github.com/pantheon-systems/solr-power/pull/448)].
 
 ### 2.1.4 (April 24, 2020) ###
 * Ensures highlighting is also applied to the post excerpt [[#446](https://github.com/pantheon-systems/solr-power/pull/446)].

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -425,7 +425,7 @@ class SolrPower_WP_Query {
 	 *
 	 * @return string
 	 */
-	function found_posts( $found_posts, $query ) {
+	public function found_posts( $found_posts, $query ) {
 		if ( ! $query->is_search() || false === SolrPower_Api::get_instance()->ping ) {
 			return $found_posts;
 		}
@@ -441,7 +441,7 @@ class SolrPower_WP_Query {
 	 *
 	 * @return mixed
 	 */
-	function posts_pre_query( $posts, $query ) {
+	public function posts_pre_query( $posts, $query ) {
 		if ( ! isset( $this->found_posts[ spl_object_hash( $query ) ] ) ) {
 			return null;
 		}

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -410,7 +410,9 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function found_posts_query( $sql, $query ) {
-		if ( ! $query->is_search() || false === SolrPower_Api::get_instance()->ping ) {
+		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
+			|| false === SolrPower_Api::get_instance()->ping
+		) {
 			return $sql;
 		}
 
@@ -426,7 +428,9 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	public function found_posts( $found_posts, $query ) {
-		if ( ! $query->is_search() || false === SolrPower_Api::get_instance()->ping ) {
+		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
+			|| false === SolrPower_Api::get_instance()->ping
+		) {
 			return $found_posts;
 		}
 

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -156,9 +156,7 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function posts_request( $request, $query ) {
-		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
-			|| false === SolrPower_Api::get_instance()->ping
-		) {
+		if ( ! $this->is_solr_query( $query ) || false === SolrPower_Api::get_instance()->ping ) {
 			return $request;
 		}
 		add_filter( 'solr_query', array( SolrPower_Api::get_instance(), 'dismax_query' ), 10, 2 );
@@ -410,9 +408,7 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	function found_posts_query( $sql, $query ) {
-		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
-			|| false === SolrPower_Api::get_instance()->ping
-		) {
+		if ( ! $this->is_solr_query( $query ) || false === SolrPower_Api::get_instance()->ping ) {
 			return $sql;
 		}
 
@@ -428,9 +424,7 @@ class SolrPower_WP_Query {
 	 * @return string
 	 */
 	public function found_posts( $found_posts, $query ) {
-		if ( ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) )
-			|| false === SolrPower_Api::get_instance()->ping
-		) {
+		if ( ! $this->is_solr_query( $query ) || false === SolrPower_Api::get_instance()->ping ) {
 			return $found_posts;
 		}
 
@@ -546,7 +540,7 @@ class SolrPower_WP_Query {
 			'post__not_in' => '-ID',
 			'name'         => 'post_name',
 		);
-		if ( ! $query->is_search() && ! $query->get( 'solr_integrate' ) ) {
+		if ( ! $this->is_solr_query( $query ) ) {
 			return '';
 		}
 
@@ -1215,6 +1209,16 @@ class SolrPower_WP_Query {
 				return '(' . $field . '_i:[* TO ' . $field_value . '])';
 				break;
 		}
+	}
+
+	/**
+	 * Whether or not the provided query should be a Solr query.
+	 *
+	 * @param object $query Query object.
+	 * @return boolean
+	 */
+	private function is_solr_query( $query ) {
+		return $query->is_search() || $query->get( 'solr_integrate' );
 	}
 
 }

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -236,11 +236,11 @@ class SolrPower_WP_Query {
 
 		$search = $search->getData();
 
-		$search_header           = $search['responseHeader'];
-		$search                  = $search['response'];
-		$query->found_posts      = $search['numFound'];
-		$this->found_posts_count = $search['numFound'];
-		$query->max_num_pages    = ceil( $search['numFound'] / $query->get( 'posts_per_page' ) );
+		$search_header      = $search['responseHeader'];
+		$search             = $search['response'];
+		$query->found_posts = $search['numFound'];
+		$this->found_posts_count[ $query->solr_query_id ] = $search['numFound'];
+		$query->max_num_pages                             = ceil( $search['numFound'] / $query->get( 'posts_per_page' ) );
 
 		SolrPower_Api::get_instance()->add_log(
 			array(
@@ -444,7 +444,7 @@ class SolrPower_WP_Query {
 			return $found_posts;
 		}
 
-		return $this->found_posts_count;
+		return $this->found_posts_count[ $query->solr_query_id ];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
 Tested up to: 5.4
-Stable tag: 2.1.4
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -163,6 +163,9 @@ To support searching by author name (e.g. where "Pantheon" would return posts au
 ```
 
 == Changelog ==
+
+= 2.2.0 (May 5, 2020) =
+* Uses `posts_pre_query` hook to support use of 'fields' in `WP_Query` [[#448](https://github.com/pantheon-systems/solr-power/pull/448)].
 
 = 2.1.4 (April 24, 2020) =
 * Ensures highlighting is also applied to the post excerpt [[#446](https://github.com/pantheon-systems/solr-power/pull/446)].

--- a/solr-power.php
+++ b/solr-power.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Solr Power
  * Description: Allows WordPress sites to index and search content with ApacheSolr.
- * Version: 2.1.4
+ * Version: 2.2.0
  * Author: Pantheon
  * Author URI: http://pantheon.io
  * Text Domain: solr-for-wordpress-on-pantheon
@@ -10,7 +10,7 @@
  * @package Solr_Power
  **/
 
-define( 'SOLR_POWER_VERSION', '2.1.4' );
+define( 'SOLR_POWER_VERSION', '2.2.0' );
 
 /**
  * Copyright (c) 2011-2020 Pantheon, Matt Weber, Solr Power contributors

--- a/tests/phpunit/wp_query/test-core-meta.php
+++ b/tests/phpunit/wp_query/test-core-meta.php
@@ -54,12 +54,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'meta_query'             => array(),
 		) );
 		$expected = array( $p1, $p2, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 
@@ -97,12 +92,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
 	public function test_meta_post_type() {
@@ -139,12 +129,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
 	public function test_meta_query_no_key() {
@@ -168,12 +153,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $p1, $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_no_value() {
@@ -198,11 +178,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p2, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 	}
 
@@ -226,11 +202,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_equals() {
@@ -254,11 +226,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_not_equals() {
@@ -283,11 +251,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_arithmetic_comparisons() {
@@ -315,11 +279,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		// <=
 		$query = new WP_Query( array(
@@ -337,11 +297,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1, $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		// >=
 		$query = new WP_Query( array(
@@ -359,11 +315,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p2, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		// >
 		$query = new WP_Query( array(
@@ -381,11 +333,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_like() {
@@ -408,11 +356,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_not_like() {
@@ -438,11 +382,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_between_not_between() {
@@ -470,11 +410,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -494,12 +430,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		$expected = array( $p1, $p3 );
 
 
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_default() {
@@ -530,12 +461,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_or() {
@@ -578,12 +504,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_id, $post_id2, $post_id3, $post_id4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 
@@ -634,12 +555,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_id7 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'meta_query'             => array(
@@ -658,12 +574,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_id2, $post_id6, $post_id7 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_compare_exists() {
@@ -682,12 +593,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $posts[0], $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_compare_exists_with_value_should_convert_to_equals() {
@@ -707,12 +613,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_compare_not_exists_should_ignore_value() {
@@ -733,12 +634,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[1] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 
@@ -768,12 +664,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_id2, $post_id3, $post_id4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -793,12 +684,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_id4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -852,12 +738,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[1], $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 	}
 
@@ -890,12 +771,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[0], $posts[1] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_or_compare_equals_and_like() {
@@ -926,12 +802,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[1], $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_or_compare_equals_and_between() {
@@ -963,12 +834,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[0], $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_single_query_compare_not_equals_negative_integer() {
@@ -1039,12 +905,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[3] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_and_compare_in_different_keys() {
@@ -1077,12 +938,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[1] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_and_compare_not_equals() {
@@ -1114,12 +970,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[3] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_and_compare_not_equals_different_keys() {
@@ -1158,12 +1009,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[2] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_and_compare_not_equals_not_in() {
@@ -1195,12 +1041,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[3] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_relation_and_compare_not_equals_and_not_like() {
@@ -1232,12 +1073,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[3] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 
@@ -1267,12 +1103,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1289,12 +1120,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1313,12 +1139,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 
 
 		$expected = array( $post_3, $post_4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1335,12 +1156,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1357,12 +1173,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_1, $post_2, $post_3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1379,12 +1190,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1401,12 +1207,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_1, $post_2, $post_4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query    = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1423,12 +1224,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $post_1, $post_3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
 			'meta_query'             => array(
@@ -1445,12 +1241,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_2, $post_4 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 		$query = new WP_Query( array(
 			'solr_integrate'         => true,
@@ -1464,12 +1255,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $post_4, $post_3, $post_2, $post_1 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 
@@ -1491,12 +1277,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p2, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, wp_list_pluck( $query->posts, 'ID' ) );
 	}
 
 	public function test_meta_query_with_orderby_meta_value_relation_or() {
@@ -1534,12 +1315,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[2], $posts[0], $posts[1] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_with_orderby_meta_value_relation_and() {
@@ -1580,12 +1356,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'fields'                 => 'ids',
 		) );
 		$expected = array( $posts[2], $posts[0], $posts[1] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_nested() {
@@ -1624,12 +1395,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_nested_two_levels_deep() {
@@ -1675,12 +1441,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $p1, $p3 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_between_not_between() {
@@ -1884,7 +1645,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			'order'          => 'DESC',
 		) );
 
-		$this->assertEquals( array( $posts[1], $posts[2], $posts[0] ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $posts[1], $posts[2], $posts[0] ), $q->posts );
 	}
 
 	public function test_orderby_clause_key_as_secondary_sort() {
@@ -1917,7 +1678,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p3, $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p3, $p1, $p2 ), $q->posts );
 	}
 
 	public function test_orderby_more_than_one_clause_key() {
@@ -1949,7 +1710,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $posts[2], $posts[0], $posts[1] ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $posts[2], $posts[0], $posts[1] ), $q->posts );
 	}
 
 	public function test_meta_query_compare_not_exists_with_another_condition_relation_or() {
@@ -1983,12 +1744,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 		) );
 
 		$expected = array( $posts[2], $posts[3] );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 
 	}
 
@@ -2015,12 +1771,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array();
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_meta_query_index_custom_fields_filter() {
@@ -2052,12 +1803,7 @@ class Tests_Solr_MetaQuery extends SolrTestBase {
 			),
 		) );
 		$expected = array( $p1, $p2 );
-		$returned = array();
-		foreach ( $query->posts as $post ) {
-			$returned[] = $post->ID;
-		}
-
-		$this->assertEqualSets( $expected, $returned );
+		$this->assertEqualSets( $expected, $query->posts );
 	}
 
 	public function test_orderby_meta_value_numeric() {

--- a/tests/phpunit/wp_query/test-date-query.php
+++ b/tests/phpunit/wp_query/test-date-query.php
@@ -272,8 +272,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $before_posts );
+		$this->assertEquals( array( $p1 ), $after_posts );
 	}
 
 
@@ -305,8 +305,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $before_posts );
+		$this->assertEqualSets( array( $p1, $p2 ), $after_posts );
 	}
 
 
@@ -336,8 +336,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $before_posts );
+		$this->assertEquals( array( $p1 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_Ym_inclusive() {
@@ -368,8 +368,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $before_posts );
+		$this->assertEqualSets( array( $p1, $p2 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_Ymd() {
@@ -398,8 +398,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $before_posts );
+		$this->assertEquals( array( $p1 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_Ymd_inclusive() {
@@ -430,8 +430,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $before_posts );
+		$this->assertEqualSets( array( $p1, $p2 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_YmdHi() {
@@ -460,8 +460,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $before_posts );
+		$this->assertEquals( array( $p1 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_YmdHi_inclusive() {
@@ -492,8 +492,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $before_posts );
+		$this->assertEqualSets( array( $p1, $p2 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_YmdHis() {
@@ -522,8 +522,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $before_posts );
+		$this->assertEquals( array( $p1 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_YmdHis_inclusive() {
@@ -554,8 +554,8 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $after_posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $before_posts );
+		$this->assertEqualSets( array( $p1, $p2 ), $after_posts );
 	}
 
 	public function test_beforeafter_with_date_string_non_parseable() {
@@ -584,7 +584,7 @@ class SolrDateQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1, $p2 ), wp_list_pluck( $before_posts, 'ID' ) );
+		$this->assertEquals( array( $p1, $p2 ), $before_posts );
 	}
 
 	public function test_date_query_year() {
@@ -938,7 +938,7 @@ class SolrDateQueryTest extends SolrTestBase {
 
 		$expected = array( $p1, $p2, );
 
-		$this->assertEqualSets( $expected, wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( $expected, $q->posts );
 	}
 
 	public function test_date_query_nested_query_multiple_columns_mixed_relations() {
@@ -1004,6 +1004,6 @@ class SolrDateQueryTest extends SolrTestBase {
 		) );
 
 		$expected = array( $p1, $p4, $p5, );
-		$this->assertEqualSets( $expected, wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( $expected, $q->posts );
 	}
 }

--- a/tests/phpunit/wp_query/test-tax-query.php
+++ b/tests/phpunit/wp_query/test-tax-query.php
@@ -58,8 +58,8 @@ class SolrTaxQueryTest extends SolrTestBase {
 	function test_wp_query_by_tax_id() {
 		$t  = self::factory()->term->create( array(
 			'taxonomy' => 'genre',
-			'slug'     => 'horror',
-			'name'     => 'Horror',
+			'slug'     => 'biography',
+			'name'     => 'Biography',
 		) );
 		$this->__create_test_post();
 
@@ -174,7 +174,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_single_term_field_name() {
@@ -202,7 +202,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 		$facets = SolrPower_WP_Query::get_instance()->facets;
 		$this->assertEquals( 1, $facets['categories']->getValues()['Foo^^'] );
 		$this->assertCount( 0, $facets['tags']->getValues() );
@@ -234,7 +234,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 		$facets = SolrPower_WP_Query::get_instance()->facets;
 		$this->assertEquals( 1, $facets['categories']->getValues()['Uncategorized^^'] );
 		$this->assertCount( 0, $facets['tags']->getValues() );
@@ -266,7 +266,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_single_term_field_term_id() {
@@ -294,7 +294,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_single_term_operator_in() {
@@ -323,7 +323,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_single_term_operator_not_in() {
@@ -352,7 +352,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 				),
 			),
 		) );
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_single_term_operator_and() {
@@ -380,7 +380,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 				),
 			),
 		) );
-		$this->assertEquals( array( $p1 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p1 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_multiple_terms_operator_in() {
@@ -416,7 +416,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_multiple_terms_operator_not_in() {
@@ -452,7 +452,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p3 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p3 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_multiple_queries_operator_not_in() {
@@ -495,7 +495,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p3 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p3 ), $q->posts );
 	}
 
 	public function test_tax_query_single_query_multiple_terms_operator_and() {
@@ -531,7 +531,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_operator_not_exists() {
@@ -561,7 +561,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p3 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p3 ), $q->posts );
 	}
 
 	public function test_tax_query_operator_exists() {
@@ -591,7 +591,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_operator_exists_should_ignore_terms() {
@@ -622,7 +622,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_operator_exists_with_no_taxonomy() {
@@ -691,7 +691,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEquals( array( $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEquals( array( $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_multiple_queries_relation_or() {
@@ -732,7 +732,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_multiple_queries_different_taxonomies() {
@@ -773,7 +773,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		) );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_two_nested_queries() {
@@ -843,7 +843,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 		_unregister_taxonomy( 'foo' );
 		_unregister_taxonomy( 'bar' );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $q->posts );
 	}
 
 	public function test_tax_query_one_nested_query_one_first_order_query() {
@@ -905,7 +905,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 		_unregister_taxonomy( 'foo' );
 		_unregister_taxonomy( 'bar' );
 
-		$this->assertEqualSets( array( $p1, $p2 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2 ), $q->posts );
 	}
 
 
@@ -976,7 +976,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 
 		_unregister_taxonomy( 'foo' );
 		_unregister_taxonomy( 'bar' );
-		$this->assertEqualSets( array( $p1, $p2, $p3 ), wp_list_pluck( $q->posts, 'ID' ) );
+		$this->assertEqualSets( array( $p1, $p2, $p3 ), $q->posts );
 	}
 
 	public function test_tax_query_relation_or_both_clauses_empty_terms() {
@@ -1287,7 +1287,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			$posts[0],
 			$posts[1],
 			$posts[2]
-		), wp_list_pluck( $results1, 'ID' ), 'Relation: OR; Operator: AND' );
+		), $results1, 'Relation: OR; Operator: AND' );
 
 		$results2 = $q->query( array(
 			'solr_integrate'         => true,
@@ -1316,7 +1316,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 		$this->assertEquals( array(
 			$posts[0],
 			$posts[3]
-		), wp_list_pluck( $results2, 'ID' ), 'Relation: AND; Operator: IN' );
+		), $results2, 'Relation: AND; Operator: IN' );
 	}
 
 }


### PR DESCRIPTION
Fixes #336. Add support for using Solr results in WP-REST API.

I'm not a WP expert so I might not have implemented this correctly. Please let me know any changes that need to be made. There are a few tests that fail locally when run with the whole suite, but pass when run individually.