### PR TITLE
Readme files: Fixing subcommand options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All Solr Power related commands are grouped into the `wp solr` command, see an e
     $ wp solr
     usage: wp solr check-server-settings
        or: wp solr delete [<id>...] [--all]
-       or: wp solr index [--batch] [--batch_size] [--post_type]
+       or: wp solr index [--batch=<batch>] [--batch_size=<size>] [--post_type=<post-type>]
        or: wp solr info [--field=<field>] [--format=<format>]
        or: wp solr optimize-index
        or: wp solr repost-schema

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ All Solr Power related commands are grouped into the `wp solr` command, see an e
     $ wp solr
     usage: wp solr check-server-settings
        or: wp solr delete [<id>...] [--all]
-       or: wp solr index [--page] [--post_type]
+       or: wp solr index [--batch] [--batch_size] [--post_type]
        or: wp solr info [--field=<field>] [--format=<format>]
        or: wp solr optimize-index
        or: wp solr repost-schema

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,7 @@ All Solr Power related commands are grouped into the `wp solr` command, see an e
     $ wp solr
     usage: wp solr check-server-settings
        or: wp solr delete [<id>...] [--all]
-       or: wp solr index [--batch] [--batch_size] [--post_type]
+       or: wp solr index [--batch=<batch>] [--batch_size=<size>] [--post_type=<post-type>]
        or: wp solr info [--field=<field>] [--format=<format>]
        or: wp solr optimize-index
        or: wp solr repost-schema

--- a/readme.txt
+++ b/readme.txt
@@ -94,7 +94,7 @@ All Solr Power related commands are grouped into the `wp solr` command, see an e
     $ wp solr
     usage: wp solr check-server-settings
        or: wp solr delete [<id>...] [--all]
-       or: wp solr index [--page] [--post_type]
+       or: wp solr index [--batch] [--batch_size] [--post_type]
        or: wp solr info [--field=<field>] [--format=<format>]
        or: wp solr optimize-index
        or: wp solr repost-schema


### PR DESCRIPTION
Bring Readme files to a current state for a index subcommand.

We also need to change it at https://wordpress.org/plugins/solr-power/