### PR TITLE
Added option to disable setQueryAlternative 

### DIFF
--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -619,8 +619,18 @@ class SolrPower_Api {
 	 * @return Solarium\QueryType\Select\Query\Query
 	 */
 	function dismax_query( $query, $dismax ) {
-		$dismax->setQueryAlternative( $query->getQuery() );
-		$query->setQuery( '' );
+		
+		/* Query alternative seems to be the wrong approach here. Define SOLRPOWR_DISABLE_QUERY_ALT
+		 * to get proper boosting behavior.
+		 * See: https://github.com/pantheon-systems/solr-power/issues/371
+		 */
+
+		if ( !defined('SOLRPOWER_DISABLE_QUERY_ALT') ) {
+			$dismax->setQueryAlternative( $query->getQuery() );
+			$query->setQuery( '' );
+		}
+
+		
 
 		return $query;
 	}

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -433,9 +433,11 @@ class SolrPower_Api {
 			 *
 			 * @param string $solr_boost_query String of items, with their boost applied.
 			 */
-			$solr_boost_query = apply_filters( 'solr_boost_query', 'post_title^2 post_content^1.2' );
-			if ( false !== $solr_boost_query ) {
-				$dismax->setBoostFunctions( $solr_boost_query );
+			if ( !defined('SOLRPOWER_DISABLE_QUERY_ALT') ) {
+				$solr_boost_query = apply_filters( 'solr_boost_query', 'post_title^2 post_content^1.2' );
+				if ( false !== $solr_boost_query ) {
+					$dismax->setBoostFunctions( $solr_boost_query );
+				}
 			}
 
 			/**

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -205,8 +205,10 @@ class SolrPower_WP_Query {
 				$sortby = $this->parse_orderby( $orderby, $query );
 			}
 		} else {
+			//
 			// Boost partial match on post_title to simulate WordPress' use of MySQL ORDER BY CASE.
-			if ( $query->get( 's' ) ) {
+			//
+			if ( !defined('SOLRPOWER_DISABLE_QUERY_ALT') && $query->get( 's' ) ) {
 				$extra['sort_before'][ "query({!dismax qf=post_title v='\"" . addslashes( $query->get( 's' ) ) . "\"'})" ] = 'desc';
 			}
 		}


### PR DESCRIPTION
In response to https://github.com/pantheon-systems/solr-power/issues/371 , this pull request allows you to define a constant SOLRPOWER_DISABLE_QUERY_ALT in order to work around the problem of setQueryAlternative() and the 'post title hack' causing problems with boosting. 