### PR TITLE
Updated readme to fix lando confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ In a local development environment, you can point Solr Power to a custom Solr in
     add_filter( 'solr_scheme', function(){ return 'http'; });
     define( 'SOLR_PATH', '/solr/wordpress/' );
 
+** Note for Lando users **
+
+If you are using lando for development, the MU plugin is not needed. Lando auto configures everything for your local environment to connect to the docker index it maintains and if you overrite the ENV variables it will mess with that configuration.
+
 ## Development ##
 
 This plugin is under active development on GitHub:

--- a/readme.txt
+++ b/readme.txt
@@ -60,6 +60,10 @@ In a local development environment, you can point Solr Power to a custom Solr in
     add_filter( 'solr_scheme', function(){ return 'http'; });
     define( 'SOLR_PATH', '/solr/wordpress/' );
 
+** Note for Lando users **
+
+If you are using lando for development, the MU plugin is not needed. Lando auto configures everything for your local environment to connect to the docker index it maintains and if you overrite the ENV variables it will mess with that configuration.
+
 == Development ==
 
 This plugin is under active development on GitHub:


### PR DESCRIPTION
I recently setup Solr Power on a local lando instance and ran into a confusion with the documentation. I interpreted the local setup as any local dev environment needed an MU plugin to function. So I setup the MU plugin before activating the plugin and because of that it hid the actual auto configuration from lando. Spent a few hours trying to configure it to work against the lando Docker index image with no luck. Talked to Pantheon support with no luck either. Took me posting to the Slack Community for someone to point out my misstep. I added this to help the next dev not make the same subtle mistake I did in interpreting the documentation that way.