### PR TITLE
Found posts don't need to be mapped for posts_pre_query

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -463,14 +463,7 @@ class SolrPower_WP_Query {
 			return null;
 		}
 
-		$new_posts = $this->found_posts[ $query->solr_query_id ];
-
-		return array_map(
-			function ( $post ) {
-				return $post->ID;
-			},
-			$new_posts
-		);
+		return $this->found_posts[ $query->solr_query_id ];
 	}
 
 	/**


### PR DESCRIPTION
Found posts don't need to be mapped for `posts_pre_query` filter. This mapping is taken care of by the core query.

Fixes #520.