### PR TITLE
Cast options as an array to remove foreach warning

### DIFF
--- a/includes/class-solrpower-options.php
+++ b/includes/class-solrpower-options.php
@@ -91,7 +91,7 @@ class SolrPower_Options {
 		$option_page = sanitize_text_field( $_POST['option_page'] );
 		check_admin_referer( $option_page . '-options' );
 		$whitelist_options = apply_filters( 'whitelist_options', array() );
-		$options           = $whitelist_options[ $option_page ];
+		$options           = (array) $whitelist_options[ $option_page ];
 		foreach ( $options as $option ) {
 			$option = trim( $option );
 			$value  = null;

--- a/includes/class-solrpower-options.php
+++ b/includes/class-solrpower-options.php
@@ -91,8 +91,8 @@ class SolrPower_Options {
 		$option_page = sanitize_text_field( $_POST['option_page'] );
 		check_admin_referer( $option_page . '-options' );
 		$whitelist_options = apply_filters( 'whitelist_options', array() );
-		$options           = (array) $whitelist_options[ $option_page ];
-		foreach ( $options as $option ) {
+		$options           = $whitelist_options[ $option_page ];
+		foreach ( (array) $options as $option ) {
 			$option = trim( $option );
 			$value  = null;
 			if ( isset( $_POST[ $option ] ) ) {


### PR DESCRIPTION
PHP warning about invalid argument to foreach(). Casting as an array to ensure at least an empty array is passed to foreach().

```
PHP Warning:  Invalid argument supplied for foreach() in /code/wp-content/plugins/solr-power/includes/class-solrpower-options.php on line 95
```