### PR TITLE
Fix failing Circle CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
       - run:
           name: "Fix pubkeys"
           command: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
       - run:
           name: "Install Extras"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ jobs:
           command: |
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest
             composer phpunit
-            WP_MULTISITE=1 composer phpunit
             rm -rf $WP_TESTS_DIR $WP_CORE_DIR
             bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 nightly true
-            composer phpunit
+            WP_MULTISITE=1 composer phpunit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,6 @@ jobs:
             yes '' | sudo pecl install imagick || true
             sudo docker-php-ext-enable imagick
             sudo docker-php-ext-install mysqli
-            sudo apt-get install mariadb-client-10.5
       - run:
           name: "Run Tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           paths:
             - vendor
       - run:
-          name: "Fix pubkeys"
+          name: "Add PUBKEYs"
           command: |
             sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,10 @@ jobs:
           paths:
             - vendor
       - run:
+        name: "Fix pubkeys"
+        command: |
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
+      - run:
           name: "Install Extras"
           command: |
             sudo apt-get update
@@ -108,6 +112,7 @@ jobs:
             yes '' | sudo pecl install imagick || true
             sudo docker-php-ext-enable imagick
             sudo docker-php-ext-install mysqli
+            sudo apt-get install mariadb-client-10.5
       - run:
           name: "Run Tests"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   lint:
     working_directory: ~/pantheon-systems/solr-power
     docker:
-      - image: quay.io/pantheon-public/build-tools-ci:6.x
+      - image: quay.io/pantheon-public/build-tools-ci:8.x-php7.4
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,8 @@ jobs:
           paths:
             - vendor
       - run:
-        name: "Fix pubkeys"
-        command: |
+          name: "Fix pubkeys"
+          command: |
           sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4EB27DB2A3B88B8B
       - run:
           name: "Install Extras"


### PR DESCRIPTION
Circle CI tests are failing at the PHP Unit step due to the lack of a recognized PUBKEY for the `apt` functions. (see https://app.circleci.com/pipelines/github/pantheon-systems/solr-power/1045/workflows/a5639025-0328-43b1-9af7-715a60903139/jobs/3320/parallel-runs/0/steps/0-105)

This PR adds a step in `config.yml` that adds the missing PUBKEY.

It also does some quality-of-life improvements using a newer Quay docker image and removing the _third_ call to run PHPUnit. (Only two are required.)