### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners. See:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @pantheon-systems/cms-ecosystem


### PR DESCRIPTION
Adds a CODEOWNERS file and sets @pantheon-systems/cms-ecosystem as the repository owner.