### PR TITLE
[CMS-1033] Update build-tag.yml

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -22,8 +22,9 @@ jobs:
         npm ci
         npm run build
         composer install --no-dev -o
+
     - name: Setup
-      run: 'echo "VERSION=$(cat ./package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[[:space:]]')" >> $GITHUB_ENV'
+      run: 'echo "VERSION=$(jq -r .version ./package.json)" >> $GITHUB_ENV'
 
     - name: Tag
       run: |


### PR DESCRIPTION
Fixes invalid yml [issue](https://github.com/pantheon-systems/solr-power/actions/runs/3490181759/workflow). Switches Setup step to use `jq` which is available according to https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md