### PR TITLE
Release 2.4.5 Restore missing vendor directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Changelog ##
+
+## 2.4.5 (April 9, 2023) ##
+* Fixes missing vendor/ directory in previous release [[#580](https://github.com/pantheon-systems/solr-power/pull/580)]
+
 ## 2.4.4 (April 7, 2023) ##
 * Update Composer dependencies [[#576](https://github.com/pantheon-systems/solr-power/pull/576)] [[#574](https://github.com/pantheon-systems/solr-power/pull/574)] [[#573](https://github.com/pantheon-systems/solr-power/pull/573)]
 * Fix failing tests [[#577](https://github.com/pantheon-systems/solr-power/pull/577)]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
 **Tested up to:** 6.2  
-**Stable tag:** 2.4.4  
+**Stable tag:** 2.4.5  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solr-power",
-  "version": "2.4.3",
+  "version": "2.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solr-power",
-      "version": "2.4.3",
+      "version": "2.4.5",
       "devDependencies": {
         "grunt": "^1.6.1",
         "grunt-autoprefixer": "~3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solr-power",
-  "version": "2.4.3",
+  "version": "2.4.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/pantheon-systems/solr-power.git"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
 Tested up to: 6.2
-Stable tag: 2.4.4
+Stable tag: 2.4.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -227,6 +227,9 @@ To force-commit data when this variable is defined outside of a normal cron run,
       wp solr commit
 
 == Changelog ==
+
+= 2.4.5 (April 9, 2023) =
+* Fixes missing vendor/ directory in previous release [[#580](https://github.com/pantheon-systems/solr-power/pull/580)]
 
 = 2.4.4 (April 7, 2023) =
 * Update Composer dependencies [[#576](https://github.com/pantheon-systems/solr-power/pull/576)] [[#574](https://github.com/pantheon-systems/solr-power/pull/574)] [[#573](https://github.com/pantheon-systems/solr-power/pull/573)]

--- a/solr-power.php
+++ b/solr-power.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Solr Power
  * Description: Allows WordPress sites to index and search content with ApacheSolr.
- * Version: 2.4.4
+ * Version: 2.4.5
  * Author: Pantheon
  * Author URI: http://pantheon.io
  * Text Domain: solr-for-wordpress-on-pantheon
@@ -10,7 +10,7 @@
  * @package Solr_Power
  **/
 
-define( 'SOLR_POWER_VERSION', '2.4.4' );
+define( 'SOLR_POWER_VERSION', '2.4.5' );
 
 /**
  * Copyright (c) 2011-2022 Pantheon, Matt Weber, Solr Power contributors


### PR DESCRIPTION
No actual changes, but #578 was missing the version bump in package.json failing the deploy pipeline. Tag for 2.4.4 is missing the vendor directory.