### PR TITLE
[CMSP-486] Add is_solr_query filter

### DIFF
--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -1245,7 +1245,16 @@ class SolrPower_WP_Query {
 	 * @return boolean
 	 */
 	private function is_solr_query( $query ) {
-		return $query->is_search() || $query->get( 'solr_integrate' );
+		$is_solr_query = $query->is_search() || $query->get( 'solr_integrate' );
+		/**
+		 * Filter is_solr_query
+		 *
+		 * Enables the ability to turn off Solr for queries.
+		 *
+		 * @param boolean  $enabled Should Solr run for this query?
+		 * @param WP_Query $query   The WP_Query.
+		 */
+		return apply_filters( 'is_solr_query', $is_solr_query, $query );
 	}
 
 }

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -1245,7 +1245,7 @@ class SolrPower_WP_Query {
 	 * @return boolean
 	 */
 	private function is_solr_query( $query ) {
-		$is_solr_query = $query->is_search() || $query->get( 'solr_integrate' );
+		$enabled = $query->is_search() || $query->get( 'solr_integrate' );
 		/**
 		 * Filter is_solr_query
 		 *
@@ -1254,7 +1254,7 @@ class SolrPower_WP_Query {
 		 * @param boolean  $enabled Should Solr run for this query?
 		 * @param WP_Query $query   The WP_Query.
 		 */
-		return apply_filters( 'is_solr_query', $is_solr_query, $query );
+		return apply_filters( 'is_solr_query', $enabled, $query );
 	}
 
 }


### PR DESCRIPTION
Right now it's impossible to turn off Solr for specific types of searches. 

Another considered solution was to allow for $query->get( 'solr_integrate' ); to be set to false and have that overwrite the result of $query->is_search() but the filter seems like it would give more flexibility and be clearer in it's goal.