### PR TITLE
[BUGS-6482] Disable Auto-commit by default

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -70,14 +70,8 @@ jobs:
 
     - name: Install dependencies
       run: composer install
-
     - name: "Run Tests"
-      run: |
-        bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest
-        composer phpunit
-        rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-        bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 nightly true
-        WP_MULTISITE=1 composer phpunit
+      run: bash bin/phpunit-test.sh
 
   test-behat:
     needs: test-phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets/css/*.css
 assets/css/*.css.map
 assets/js/*.js
 composer.lock
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes typo in var which caused undefined notice [[#582](https://github.com/pantheon-systems/solr-power/pull/582)]
 * Update Composer dependencies [[#576](https://github.com/pantheon-systems/solr-power/pull/576)] [[#574](https://github.com/pantheon-systems/solr-power/pull/583)] [[#573](https://github.com/pantheon-systems/solr-power/pull/584)]
 * Updates security policy [[#589](https://github.com/pantheon-systems/solr-power/pull/589)]
+* Disable auto-commit by default. [[#591](https://github.com/pantheon-systems/solr-power/pull/591)]
 
 ### 2.4.5 (April 9, 2023) ###
 * Fixes missing vendor/ directory in previous release [[#580](https://github.com/pantheon-systems/solr-power/pull/580)]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
 **Tested up to:** 6.2  
-**Stable tag:** 2.4.6-dev  
+**Stable tag:** 2.5.0-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -204,16 +204,19 @@ Add the following to your `functions.php` file.
 
 ## Explicit Commit vs Autocommit ##
 
-Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and
-relevancy ratings accordingly before that data can appear in search results. By default, Solr Search for WordPress does this when it sends every post. It may be necessary on occasion to disable this behavior (e.g. when importing a lot of posts via CSV). To do this, you need add the following code to your index.php in the root of your site install:
+Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results. 
+
+By default, Solr Search for WordPress has auto-commit disabled. The index is committed when the uncommitted item is two minutes old, or the cron runs. By default, the cron runs on the Pantheon platform every hour.
+
+When autocommit is enabled, Solr Search for WordPress commits data when it sends every post. When running on Pantheon, we recommend leaving autocommit disabled to aid overall site performance.
+
+To enable autocommit, add the following to `wp-config.php` or an mu-plugin.
 
 ```php
-define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', true );
+define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', false );
 ```
 
-When this variable is defined, Solr Search for WordPress will not commit the index until the uncommitted item is two minutes old or the cron runs. By default, the cron runs on the Pantheon platform every hour.
-
-To force-commit data when this variable is defined outside of a normal cron run, from the command line, you can run the command below or simply force a cron-run.
+To force-commit data outside of a normal cron run, from the command line, you can run the command below or simply force a cron-run.
 
 ```bash
 wp solr commit

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -50,6 +50,7 @@ fi
 set -e
 
 install_wp() {
+
 	if [ -d $WP_CORE_DIR ]; then
 		return;
 	fi
@@ -87,7 +88,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php	
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
 }
 
 install_test_suite() {

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -50,7 +50,6 @@ fi
 set -e
 
 install_wp() {
-
 	if [ -d $WP_CORE_DIR ]; then
 		return;
 	fi
@@ -88,7 +87,7 @@ install_wp() {
 		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
 	fi
 
-	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php	
 }
 
 install_test_suite() {

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+DIRNAME=$(dirname "$0")
+bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
+composer test
+rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+
+bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest true
+WP_MULTISITE=1 composer test

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "support": {
-      "issues": "https://github.com/pantheon-systems/solr-power/issues"
+        "issues": "https://github.com/pantheon-systems/solr-power/issues"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
@@ -45,7 +45,15 @@
         "phpcs": "vendor/bin/phpcs",
         "phpcbf": "vendor/bin/phpcbf",
         "phpunit": "vendor/bin/phpunit",
-        "test": "@phpunit"
+        "phpunit-shouldcommit": [
+            "vendor/bin/phpunit --group should-commit --filter testShouldNotCommitWhenConstNull",
+            "vendor/bin/phpunit --group should-commit --filter testShouldNotCommitWhenConstTrue",
+            "vendor/bin/phpunit --group should-commit --filter testShouldCommitWhenConstFalse"
+        ],
+        "test": [
+            "@phpunit-shouldcommit",
+            "@phpunit"
+        ]
     },
     "autoload": {
         "classmap": [

--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -734,16 +734,27 @@ class SolrPower_Sync {
 	 * when the plugin posts data to Solr, but your Solr instance will need
 	 * to have a cron job enabled that does a hard commit on a regular basis.
 	 *
-	 * To disable commiting to Solr, add the following to your wp-config.php
+	 *
+	 * To enable commiting to Solr, add the following to your wp-config.php
 	 *
 	 * <code>
-	 * define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', true );
+	 * define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', false );
 	 * </code>
+	 *
+	 * As of 2.5.0, the default behavior is to not auto-commit.
+	 * Yes, this function could be more concise, but the double-negative logic
+	 * can be confusing so making the logic as explicit as possible.
 	 *
 	 * @see https://cwiki.apache.org/confluence/display/solr/UpdateXmlMessages#UpdateXmlMessages-%22commit%22and%22optimize%22
 	 * @return bool Whether to commit immediately when writing site data to Solr.
 	 */
 	function should_commit() {
-		return ! ( defined( 'SOLRPOWER_DISABLE_AUTOCOMMIT' ) && SOLRPOWER_DISABLE_AUTOCOMMIT );
+		// Auto-commit is explicitly enabled by not disabling it 🤮.
+		if ( defined( 'SOLRPOWER_DISABLE_AUTOCOMMIT' ) && ! SOLRPOWER_DISABLE_AUTOCOMMIT ) {
+			return true;
+		}
+
+		// Do not autocommit, as cron will take care of it.
+		return false;
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solr-power",
-  "version": "2.4.5",
+  "version": "2.5.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "solr-power",
-      "version": "2.4.5",
+      "version": "2.5.0-dev",
       "devDependencies": {
         "grunt": "^1.6.1",
         "grunt-autoprefixer": "~3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solr-power",
-  "version": "2.4.5",
+  "version": "2.5.0-dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/pantheon-systems/solr-power.git"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,4 +11,9 @@
 			<directory prefix="test-" suffix=".php">./tests/phpunit/</directory>
 		</testsuite>
 	</testsuites>
+	<groups>
+	<exclude>
+		<group>should-commit</group>
+	</exclude>
+</groups>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
 Tested up to: 6.2
-Stable tag: 2.4.6-dev
+Stable tag: 2.5.0-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -78,8 +78,8 @@ For further documentation, such as available filters and working with the `SolrP
 
 You may notice there are two sets of tests running, on two different services:
 
-* Travis CI runs the [PHPUnit](https://phpunit.de/) test suite against a Solr instance.
-* Circle CI runs the [Behat](http://behat.org/) test suite against a Pantheon site, to ensure the plugin's compatibility with the Pantheon platform.
+* [PHPUnit](https://phpunit.de/) test suite against a Solr instance.
+* The [Behat](http://behat.org/) test suite against a Pantheon site, to ensure the plugin's compatibility with the Pantheon platform.
 
 Both of these test suites can be run locally, with a varying amount of setup.
 
@@ -215,14 +215,17 @@ Add the following to your `functions.php` file.
 
 = Explicit Commit vs Autocommit =
 
-Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and
-relevancy ratings accordingly before that data can appear in search results. By default, Solr Search for WordPress does this when it sends every post. It may be necessary on occasion to disable this behavior (e.g. when importing a lot of posts via CSV). To do this, you need add the following code to your index.php in the root of your site install:
+Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results. 
 
-      define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', true );
+By default, Solr Search for WordPress has auto-commit disabled. The index is committed when the uncommitted item is two minutes old, or the cron runs. By default, the cron runs on the Pantheon platform every hour.
 
-When this variable is defined, Solr Search for WordPress will not commit the index until the uncommitted item is two minutes old or the cron runs. By default, the cron runs on the Pantheon platform every hour.
+When autocommit is enabled, Solr Search for WordPress commits data when it sends every post. When running on Pantheon, we recommend leaving autocommit disabled to aid overall site performance.
 
-To force-commit data when this variable is defined outside of a normal cron run, from the command line, you can run the command below or simply force a cron-run.
+To enable autocommit, add the following to `wp-config.php` or an mu-plugin.
+
+      define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', false );
+
+To force-commit data outside of a normal cron run, from the command line, you can run the command below or simply force a cron-run.
 
       wp solr commit
 
@@ -237,6 +240,7 @@ Please report security bugs found in the source code of the Solr Power plugin th
 * Fixes typo in var which caused undefined notice [[#582](https://github.com/pantheon-systems/solr-power/pull/582)]
 * Update Composer dependencies [[#576](https://github.com/pantheon-systems/solr-power/pull/576)] [[#574](https://github.com/pantheon-systems/solr-power/pull/583)] [[#573](https://github.com/pantheon-systems/solr-power/pull/584)]
 * Updates security policy [[#589](https://github.com/pantheon-systems/solr-power/pull/589)]
+* Disable auto-commit by default. [[#591](https://github.com/pantheon-systems/solr-power/pull/591)]
 
 = 2.4.5 (April 9, 2023) =
 * Fixes missing vendor/ directory in previous release [[#580](https://github.com/pantheon-systems/solr-power/pull/580)]
@@ -438,3 +442,8 @@ Please report security bugs found in the source code of the Solr Power plugin th
 
 = 0.0 =
 * Note this started as a fork of this wonderful project: https://github.com/mattweber/solr-for-wordpress
+
+== Upgrade Notice ==
+
+= 2.5.0-dev =
+Changes the default auto-commit behavior to disabled. See [the README](https://github.com/pantheon-systems/solr-power/#explicit-commit-vs-autocommit) for instructions for keeping enabled.

--- a/solr-power.php
+++ b/solr-power.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Solr Power
  * Description: Allows WordPress sites to index and search content with ApacheSolr.
- * Version: 2.4.6-dev
+ * Version: 2.5.0-dev
  * Author: Pantheon
  * Author URI: http://pantheon.io
  * Text Domain: solr-for-wordpress-on-pantheon
@@ -10,7 +10,7 @@
  * @package Solr_Power
  **/
 
-define( 'SOLR_POWER_VERSION', '2.4.6-dev' );
+define( 'SOLR_POWER_VERSION', '2.5.0-dev' );
 
 /**
  * Copyright (c) 2011-2022 Pantheon, Matt Weber, Solr Power contributors

--- a/tests/phpunit/class-solr-test-base.php
+++ b/tests/phpunit/class-solr-test-base.php
@@ -22,6 +22,11 @@ class SolrTestBase extends WP_UnitTestCase{
 	function setUp() {
 		parent::setUp();
 
+		# Plugin now (2.5.0) defaults to true, but tests expect it.
+		if ( ! defined('SOLRPOWER_DISABLE_AUTOCOMMIT') ) {
+			define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', false);
+		}
+
 		if ( ! SolrPower_API::get_instance()->ping_server() ) {
 			$this->fail( 'Cannot connect to Solr. Solr is required for Solr Power tests.' );
 		}

--- a/tests/phpunit/test-shouldcommit.php
+++ b/tests/phpunit/test-shouldcommit.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @group should-commit
+ */
+class ShouldCommitTest extends WP_UnitTestCase
+{
+    public function testShouldNotCommitWhenConstNull(): void
+    {
+        if ( defined('SOLRPOWER_DISABLE_AUTOCOMMIT') ) {
+            echo var_dump(SOLRPOWER_DISABLE_AUTOCOMMIT).PHP_EOL;
+            $this->fail("SOLRPOWER_DISABLE_AUTOCOMMIT unexpectedly defined.");
+        }
+        $result = SolrPower_Sync::get_instance()->should_commit();
+        $this->assertFalse($result);
+    }
+
+    public function testShouldNotCommitWhenConstTrue(): void
+    {
+        define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', true);
+        $result = SolrPower_Sync::get_instance()->should_commit();
+        $this->assertFalse($result);  
+    }
+
+    public function testShouldCommitWhenConstFalse(): void
+    {
+        define( 'SOLRPOWER_DISABLE_AUTOCOMMIT', false);
+        $result = SolrPower_Sync::get_instance()->should_commit();
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
The default behavior is now to allow cron to push solr commits regularly instead of autocommit. See #559 and #549 for details when this option was initially added last year— now we're making it the default behavior.

Users can still enable auto-commit by explicitly setting `SOLRPOWER_DISABLE_AUTOCOMMIT` to `false`.