### PR TITLE
Lint README for lost spacing

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -30,7 +30,13 @@ jobs:
 
     - name: Run PHP Lint
       run: composer phpcs
-
+  validate-readme-spacing:
+    name: Validate README Spacing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pantheon-systems/validate-readme-spacing@v1
   test-phpunit:
     needs: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensures the header section of README.md handles newlines correctly in rendered markdown.

See https://github.com/pantheon-systems/validate-readme-spacing