### PR TITLE
Adds a test against the latest nightly version

### DIFF
--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -19,3 +19,4 @@ reset_test_environment
 
 echo "Testing with latest WordPress nightly version..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 nightly true
+composer test

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -2,6 +2,11 @@
 set -e
 
 DIRNAME=$(dirname "$0")
+
+reset_test_environment() {
+  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+}
+
 echo "Testing on WordPress single site..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 composer test
@@ -14,7 +19,3 @@ reset_test_environment
 
 echo "Testing with latest WordPress nightly version..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 nightly true
-
-reset_test_environment() {
-  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
-}

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -2,9 +2,19 @@
 set -e
 
 DIRNAME=$(dirname "$0")
+echo "Testing on WordPress single site..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 composer test
-rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+reset_test_environment
 
+echo "Testing on WordPress multisite..."
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest true
 WP_MULTISITE=1 composer test
+reset_test_environment
+
+echo "Testing with latest WordPress nightly version..."
+bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 nightly true
+
+reset_test_environment() {
+  rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+}


### PR DESCRIPTION
This PR adds another run-through of the test suite using the latest nightly version of WP.

See: https://github.com/pantheon-systems/cms-platform/discussions/45