### PR TITLE
[BUGS-6558] Fix Solr not indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog ##
 
 ### 2.5.1-dev ###
+* Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]
 
 ### 2.5.0 ###
 * Updates CONTRIBUTING.md [[#585](https://github.com/pantheon-systems/solr-power/pull/585)] [[#594](https://github.com/pantheon-systems/solr-power/pull/594)]

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pantheon-systems/solr-power",
     "description": "An open source plugin to connect to Pantheon's Apache Solr search infrastructure, or your own!",
     "type": "wordpress-plugin",
-    "license": "GPLv2 or later",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Pantheon",

--- a/includes/class-solrpower-sync.php
+++ b/includes/class-solrpower-sync.php
@@ -433,15 +433,13 @@ class SolrPower_Sync {
 				if ( $commit && $this->should_commit() ) {
 					syslog( LOG_INFO, 'telling Solr to commit' );
 					$update->addCommit();
-					$solr->update( $update );
 				}
 
 				if ( $optimize ) {
-					$update = $solr->createUpdate();
 					$update->addOptimize();
-					$solr->update( $update );
 					syslog( LOG_INFO, 'Optimizing: ' . get_bloginfo( 'wpurl' ) );
 				}
+				$solr->update( $update );
 				wp_cache_delete( 'solr_index_stats', 'solr' );
 			} else {
 				syslog( LOG_ERR, 'failed to get a solr instance created' );

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ Please report security bugs found in the source code of the Solr Power plugin th
 == Changelog ==
 
 = 2.5.1-dev =
+* Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]
 
 = 2.5.0 =
 * Updates CONTRIBUTING.md [[#585](https://github.com/pantheon-systems/solr-power/pull/585)] [[#594](https://github.com/pantheon-systems/solr-power/pull/594)]


### PR DESCRIPTION
Fixes case where `wp solr index` returns "Success" but `wp solr stats` shows that nothing is indexed.

solr->update() was not called when $optimize and should_commit are both false.

Props @DmytroLytvynchenko for assisting with the patch.