### PR TITLE
Add script to tag a prerelease tag with assets

### DIFF
--- a/bin/prerelease.sh
+++ b/bin/prerelease.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eou pipefail
+
+DIRNAME=$(dirname "$0")
+
+CURRENT_HASH=$(git rev-parse --short HEAD)
+
+cd "$DIRNAME/.."
+
+npm ci 
+npm run build 
+composer install --no-dev -o
+
+VERSION=$(jq -r .version ./package.json)
+PRERELEASE_VERSION="${VERSION}-${CURRENT_HASH}"
+
+git checkout -b "prerelease-${PRERELEASE_VERSION}"
+git add -f assets/* vendor/
+git commit -m "Release ${PRERELEASE_VERSION}"
+git tag "${PRERELEASE_VERSION}"
+git push --tags
+
+git checkout -


### PR DESCRIPTION
This could likely be combined with the build-tag workflow to a single tag script with parameters but not refactoring that right now.