### PR TITLE
Create release following tag

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -36,5 +36,7 @@ jobs:
         git commit -m "Release $VERSION"
         git tag "$VERSION"
         git push --tags
+        gh release create "$VERSION" -t "$VERSION" --generate-notes
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Always be releasing.

On merge to main, build step will immediately publish a release, triggering the WordPress.org publish workflow.