### PR TITLE
Draft release on merge to main

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -36,7 +36,7 @@ jobs:
         git commit -m "Release $VERSION"
         git tag "$VERSION"
         git push --tags
-        gh release create "$VERSION" -t "$VERSION" --generate-notes
+        gh release create "$VERSION" -t "$VERSION" --generate-notes -d
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Follows #603. Discovered on merge the release created fine, but automation didn't run, apparently because it was triggered by an action. Instead we'll draft the release, and maintainer can publish, triggering the .org release.