### PR TITLE
[BUGS-6792] clear_object_cache handles protected cache property (OCP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog ##
 
 ### 2.5.2-dev ###
-* Fix incompatability with Object Cache Pro when running "wp solr index"
+* Fix incompatability with Object Cache Pro when running "wp solr index" [[#611](https://github.com/pantheon-systems/solr-power/pull/611)]
 
 ### 2.5.1 ###
 * Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog ##
 
 ### 2.5.2-dev ###
+* Fix incompatability with Object Cache Pro when running "wp solr index"
 
 ### 2.5.1 ###
 * Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]

--- a/includes/class-solrpower-batch-index.php
+++ b/includes/class-solrpower-batch-index.php
@@ -266,11 +266,18 @@ class SolrPower_Batch_Index {
 			return;
 		}
 
-		$wp_object_cache->group_ops      = array();
-		$wp_object_cache->stats          = array();
-		$wp_object_cache->memcache_debug = array();
-		$wp_object_cache->cache          = array();
+		$properties_to_reset = array( 'group_ops', 'stats', 'memcache_debug', 'cache' );
+		$reflection = new ReflectionClass( $wp_object_cache );
 
+		// Set the property to an empty array if it exists and is not private/protected
+		foreach ( $properties_to_reset as $property_name ) {
+			if ( $reflection->hasProperty( $property_name ) ) {
+				$property = $reflection->getProperty( $property_name );
+				if ( ! $property->isPrivate() && ! $property->isProtected() ) {
+					$wp_object_cache->$property_name = array();
+				}
+			}
+		}
 		if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
 			$wp_object_cache->__remoteset();
 		}

--- a/includes/class-solrpower-batch-index.php
+++ b/includes/class-solrpower-batch-index.php
@@ -269,7 +269,7 @@ class SolrPower_Batch_Index {
 		$properties_to_reset = array( 'group_ops', 'stats', 'memcache_debug', 'cache' );
 		$reflection = new ReflectionClass( $wp_object_cache );
 
-		// Set the property to an empty array if it exists and is not private/protected
+		// Set the property to an empty array if it exists and is not private/protected.
 		foreach ( $properties_to_reset as $property_name ) {
 			if ( $reflection->hasProperty( $property_name ) ) {
 				$property = $reflection->getProperty( $property_name );

--- a/readme.txt
+++ b/readme.txt
@@ -236,6 +236,7 @@ Please report security bugs found in the source code of the Solr Power plugin th
 == Changelog ==
 
 = 2.5.2-dev =
+* Fix incompatability with Object Cache Pro when running "wp solr index"
 
 = 2.5.1 =
 * Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]

--- a/readme.txt
+++ b/readme.txt
@@ -236,7 +236,7 @@ Please report security bugs found in the source code of the Solr Power plugin th
 == Changelog ==
 
 = 2.5.2-dev =
-* Fix incompatability with Object Cache Pro when running "wp solr index"
+* Fix incompatability with Object Cache Pro when running "wp solr index" [[#611](https://github.com/pantheon-systems/solr-power/pull/611)]
 
 = 2.5.1 =
 * Fix Solr not indexing automatically [[#598](https://github.com/pantheon-systems/solr-power/pull/598)]


### PR DESCRIPTION
Plugin was written with wp-redis in mind, but OCP's cache property is private where wp-redis is not.

Fixes #610

Tested on solr-power site with both OCP and wp-redis installed (`else` debug statements in below output excised from final version).

## OCP
```
philtyler@Phils-MacBook-Pro solr-power % terminus remote:wp ... -- solr index
 [warning] This environment is in read-only Git mode. If you want to make changes to the codebase of this site (e.g. updating modules or plugins), you will need to toggle into read/write SFTP mode first.

Starting batch 1 of 1 at 0:00:00 elapsed time (0 indexed, 0 failed, 1 remaining)

Submitted 'Let's Go Car Shopping!' (1) to the index.
Property group_ops DNE!1
Property stats DNE!1
Property memcache_debug DNE!1
Property cache is private or protected1
Success: Indexed 1 of 1 posts.
 [notice] Command: ... -- wp solr index [Exit: 0]
```
## Wp Redis 
```
philtyler@Phils-MacBook-Pro solr-power % terminus remote:wp ... -- solr index

Starting batch 1 of 1 at 0:00:00 elapsed time (0 indexed, 0 failed, 1 remaining)

Submitted 'Let's Go Car Shopping!' (1) to the index.
Property group_ops DNE!1
Property stats DNE!1
Property memcache_debug DNE!1
Success: Indexed 1 of 1 posts.
 [notice] Command: ... -- wp solr index [Exit: 0]
```