### PR TITLE
[JFDI] Plugin deploy uses checkout@v3

### DIFF
--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -7,7 +7,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@2.1.1
       env:


### PR DESCRIPTION
See note:
https://github.com/pantheon-systems/solr-power/actions/runs/6165418241

> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
