### PR TITLE
[CMSP-721] Bump tested-up-to and output PHP Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** search  
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
-**Tested up to:** 6.3  
+**Tested up to:** 6.4.1  
 **Stable tag:** 2.5.3-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
@@ -204,7 +204,7 @@ Add the following to your `functions.php` file.
 
 ## Explicit Commit vs Autocommit ##
 
-Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results. 
+Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results.
 
 By default, Solr Search for WordPress has auto-commit disabled. The index is committed when the uncommitted item is two minutes old, or the cron runs. By default, the cron runs on the Pantheon platform every hour.
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -56,6 +56,9 @@ cd $BASH_DIR/..
 rsync -av --exclude='node_modules/' --exclude='tests/' ./* $PREPARE_DIR/wp-content/plugins/solr-power
 cd $PREPARE_DIR/wp-content/plugins/solr-power
 
+PHP_VERSION="$(terminus env:info $SITE_ENV --field=php_version)"
+echo "PHP Version: $PHP_VERSION"
+
 ###
 # Build plugin
 ###

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, Outlandish Josh, 10up, collinsinternet, andrew.taylor
 Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
-Tested up to: 6.3
+Tested up to: 6.4.1
 Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -215,7 +215,7 @@ Add the following to your `functions.php` file.
 
 = Explicit Commit vs Autocommit =
 
-Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results. 
+Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results.
 
 By default, Solr Search for WordPress has auto-commit disabled. The index is committed when the uncommitted item is two minutes old, or the cron runs. By default, the cron runs on the Pantheon platform every hour.
 


### PR DESCRIPTION
so we can ensure we're testing on PHP 8.3

Note, NewRelic is active on this site, so Behat tests will fail until pantheon-systems/infrastructure#3574 is merged, but then we can re-run and it should work