### PR TITLE
Bump "tested up to" version

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,6 @@
 name: Lint and Test
 on:
-  push:
+  pull_request:
     branches:
       - '**'
   schedule:
@@ -76,7 +76,7 @@ jobs:
       run: bash bin/phpunit-test.sh
 
   test-behat:
-    needs: 
+    needs:
       - test-phpunit
       - lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Tags:** search  
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
-**Tested up to:** 6.3  
+**Tested up to:** 6.4.1  
 **Stable tag:** 2.5.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: getpantheon, Outlandish Josh, 10up, collinsinternet, andrew.taylor
 Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
-Tested up to: 6.3
+Tested up to: 6.4.1
 Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -215,7 +215,7 @@ Add the following to your `functions.php` file.
 
 = Explicit Commit vs Autocommit =
 
-Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results. 
+Once solr has sent the data to the solr server, solr must COMMIT the data to the index and adjust the index and relevancy ratings accordingly before that data can appear in search results.
 
 By default, Solr Search for WordPress has auto-commit disabled. The index is committed when the uncommitted item is two minutes old, or the cron runs. By default, the cron runs on the Pantheon platform every hour.
 


### PR DESCRIPTION
This bumps the tested up to version which should prompt the behat tests to pass (since it won't be failing at the "validate fixture version" step).

https://github.com/pantheon-systems/solr-power/actions/workflows/lint-test.yml