### PR TITLE
[CMSP-1034] fix typo in tax_query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+### 2.5.3 (April 24, 2024) ###
+* Fixes a very old bug that would cause tax queries to be built incorrectly. [[#622](https://github.com/pantheon-systems/solr-power/pull/622)] (props [@offshorealert](https://wordpress.org/support/users/offshorealert/))
+
 ### 2.5.2 (September 12, 2023) ###
 * Fix incompatibility with Object Cache Pro when running "wp solr index" [[#611](https://github.com/pantheon-systems/solr-power/pull/611)]
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 **Tags:** search  
 **Requires at least:** 4.6  
 **Requires PHP:** 7.1  
-**Tested up to:** 6.4.1  
-**Stable tag:** 2.5.2  
+**Tested up to:** 6.5.2  
+**Stable tag:** 2.5.3  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/bin/behat-cleanup.sh
+++ b/bin/behat-cleanup.sh
@@ -20,4 +20,4 @@ set -ex
 ###
 # Delete the environment used for this test run.
 ###
-terminus multidev:delete $SITE_ENV --delete-branch --yes
+terminus multidev:delete $SITE_ENV --delete-branch --yes || true

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -740,7 +740,7 @@ class SolrPower_WP_Query {
 					$multi_query   = array();
 					$multi_query[] = '(' . $field . ':(' . implode( 'OR', $terms ) . '))';
 					if ( $tax_value['include_children'] && is_taxonomy_hierarchical( $tax_value['taxonomy'] ) ) {
-						$multi_query[] = '(parent_' . $field . ':' . implode( 'OR', $terms ) . '))';
+						$multi_query[] = '(parent_' . $field . '(:' . implode( 'OR', $terms ) . '))';
 					}
 					$query[] = '(' . implode( 'OR', $multi_query ) . ')';
 					break;

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -740,7 +740,7 @@ class SolrPower_WP_Query {
 					$multi_query   = array();
 					$multi_query[] = '(' . $field . ':(' . implode( 'OR', $terms ) . '))';
 					if ( $tax_value['include_children'] && is_taxonomy_hierarchical( $tax_value['taxonomy'] ) ) {
-						$multi_query[] = '(parent_' . $field . '(:' . implode( 'OR', $terms ) . '))';
+						$multi_query[] = '(parent_' . $field . ':(' . implode( 'OR', $terms ) . '))';
 					}
 					$query[] = '(' . implode( 'OR', $multi_query ) . ')';
 					break;

--- a/includes/class-solrpower-wp-query.php
+++ b/includes/class-solrpower-wp-query.php
@@ -740,7 +740,7 @@ class SolrPower_WP_Query {
 					$multi_query   = array();
 					$multi_query[] = '(' . $field . ':(' . implode( 'OR', $terms ) . '))';
 					if ( $tax_value['include_children'] && is_taxonomy_hierarchical( $tax_value['taxonomy'] ) ) {
-						$multi_query[] = '(parent_' . $field . ':' . implode( 'OR', $terms ) . ')';
+						$multi_query[] = '(parent_' . $field . ':' . implode( 'OR', $terms ) . '))';
 					}
 					$query[] = '(' . implode( 'OR', $multi_query ) . ')';
 					break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solr-power",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/pantheon-systems/solr-power.git"

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: getpantheon, Outlandish Josh, 10up, collinsinternet, andrew.taylor
 Tags: search
 Requires at least: 4.6
 Requires PHP: 7.1
-Tested up to: 6.4.1
-Stable tag: 2.5.2
+Tested up to: 6.5.2
+Stable tag: 2.5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -235,6 +235,9 @@ Please report security bugs found in the source code of the Solr Power plugin th
 
 == Changelog ==
 
+= 2.5.3 (April 24, 2024) =
+* Fixes a very old bug that would cause tax queries to be built incorrectly. [[#622](https://github.com/pantheon-systems/solr-power/pull/622)] (props [@offshorealert](https://wordpress.org/support/users/offshorealert/))
+
 = 2.5.2 (September 12, 2023) =
 * Fix incompatibility with Object Cache Pro when running "wp solr index" [[#611](https://github.com/pantheon-systems/solr-power/pull/611)]
 

--- a/solr-power.php
+++ b/solr-power.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Solr Power
  * Description: Allows WordPress sites to index and search content with ApacheSolr.
- * Version: 2.5.2
+ * Version: 2.5.3
  * Author: Pantheon
  * Author URI: http://pantheon.io
  * Text Domain: solr-for-wordpress-on-pantheon
@@ -10,7 +10,7 @@
  * @package Solr_Power
  **/
 
-define( 'SOLR_POWER_VERSION', '2.5.2' );
+define( 'SOLR_POWER_VERSION', '2.5.3' );
 
 /**
  * Copyright (c) 2011-2022 Pantheon, Matt Weber, Solr Power contributors

--- a/tests/phpunit/wp_query/test-tax-query.php
+++ b/tests/phpunit/wp_query/test-tax-query.php
@@ -29,7 +29,6 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		);
 		$query = new WP_Query( $args );
-		var_dump( $query->post );
 		$this->assertEquals( $p_id, $query->post->ID );
 	}
 

--- a/tests/phpunit/wp_query/test-tax-query.php
+++ b/tests/phpunit/wp_query/test-tax-query.php
@@ -29,7 +29,7 @@ class SolrTaxQueryTest extends SolrTestBase {
 			),
 		);
 		$query = new WP_Query( $args );
-
+		var_dump( $query->post );
 		$this->assertEquals( $p_id, $query->post->ID );
 	}
 


### PR DESCRIPTION
Adds customer-supplied code for tax_queries from https://wordpress.org/support/topic/issue-building-query-when-you-are-parsing-the-tax_query/ props [@offshorealert](https://wordpress.org/support/users/offshorealert/), 