### PR TITLE
[BUGS-8883] Fix custom schema path for WPCM sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 2.6.0-dev ###
 * Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://wordpress.org/support/users/sboisvert/))
+* Fixes custom schema file path for Composer Managed and other non-standard uploads directories. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
+* Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file.
 
 ### 2.5.3 (April 24, 2024) ###
 * Fixes a very old bug that would cause tax queries to be built incorrectly. [[#622](https://github.com/pantheon-systems/solr-power/pull/622)] (props [@offshorealert](https://wordpress.org/support/users/offshorealert/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Changelog ##
 
 ### 2.6.0-dev ###
-* Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://wordpress.org/support/users/sboisvert/))
+* Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://github.com/sboisvert))
 * Fixes custom schema file path for Composer Managed and other non-standard uploads directories. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
 * Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.6.0-dev ###
 * Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://wordpress.org/support/users/sboisvert/))
 * Fixes custom schema file path for Composer Managed and other non-standard uploads directories. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
-* Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file.
+* Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
 
 ### 2.5.3 (April 24, 2024) ###
 * Fixes a very old bug that would cause tax queries to be built incorrectly. [[#622](https://github.com/pantheon-systems/solr-power/pull/622)] (props [@offshorealert](https://wordpress.org/support/users/offshorealert/))

--- a/README.md
+++ b/README.md
@@ -218,7 +218,13 @@ add_filter( 'is_solr_query', function( $enabled, $query ) {
 
 ## Custom Schema file path
 
-By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path with the following filter:
+By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path using the the `solr_power_customer_schema_file_path` filter.
+
+Parameters:
+* $custom_schema_file_path (string): Default path to a custom schema file
+
+Return:
+* string: Absolute path to a custom schema.xml file.
 
 ``` php
 add_filter('solr_power_customer_schema_file_path', function($custom_schema_file_path) {

--- a/README.md
+++ b/README.md
@@ -216,6 +216,16 @@ add_filter( 'is_solr_query', function( $enabled, $query ) {
 }, 10, 2 );
 ```
 
+## Custom Schema file path
+
+By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path with the following filter:
+
+``` php
+add_filter('solr_power_customer_schema_file_path', function($custom_schema_file_path) {
+    return '/absolute/path/to/schema.xml';
+});
+```
+
 ## Common issues ##
 
 * Failing to post the schema.xml will result in an error during indexing, "Missing `post_date_iso` field."

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -123,7 +123,6 @@ class SolrPower_Api {
 		$custom_schema_file_path = apply_filters( 'solr_power_customer_schema_file_path', $custom_schema_file_path );
 
 		if ( file_exists( $custom_schema_file_path ) ) {
-			error_log( 'Solr Power: Uploading Schema from custom location' );
 			$schema = $custom_schema_file_path;
 		}
 

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -112,9 +112,9 @@ class SolrPower_Api {
 
 		$schema = SOLR_POWER_PATH . '/schema.xml';
 		$upload_dir = wp_upload_dir();
-		$custom_schema_file = path_join($upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml');
-		if ( file_exists($custom_schema_file) ) {
-			error_log('Solr Power: Uploading Schema from custom location');
+		$custom_schema_file = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
+		if ( file_exists( $custom_schema_file ) ) {
+			error_log( 'Solr Power: Uploading Schema from custom location' );
 			$schema = $custom_schema_file;
 		}
 
@@ -160,15 +160,15 @@ class SolrPower_Api {
 		$curl_opts = curl_getinfo( $ch );
 		fclose( $file );
 		if ( 200 === (int) $curl_opts['http_code'] ) {
-			# Schema Upload Success
+			// Schema Upload Success
 			$return_value = 'Schema Upload Success: ' . $curl_opts['http_code'];
-			if ($schema == $custom_schema_file) {
-				$return_value = 'Custom ' .$return_value;
+			if ( $schema == $custom_schema_file ) {
+				$return_value = 'Custom ' . $return_value;
 			}
 			return $return_value;
 		}
 
-		# Schema Upload Failure
+		// Schema Upload Failure
 		$return_value = 'Schema Upload Error: ' . $curl_opts['http_code'];
 		if ( preg_match( '#<h1>(HTTP Status [\d]+ - )?(.+)</h1>#', $response, $matches ) ) {
 			$return_value .= ' - ' . $matches[2];

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -100,6 +100,25 @@ class SolrPower_Api {
 	}
 
 	/**
+	 * Returns the absolute path to look for a custom schema.xml file.
+	 *
+	 * @return string
+	 */
+	public static function custom_schema_file_path() {
+		$upload_dir = wp_upload_dir();
+		$custom_schema_file_path = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
+
+		/**
+		 * Override the custom schema file path
+		 *
+		 * @param string $custom_schema_file_path The absolute path to a customer solr schema file.
+		 */
+		$custom_schema_file_path = apply_filters( 'solr_power_customer_schema_file_path', $custom_schema_file_path );
+
+		return $custom_schema_file_path;
+	}
+
+	/**
 	 * Submit the schema to Solr.
 	 */
 	function submit_schema() {
@@ -111,16 +130,7 @@ class SolrPower_Api {
 		 * and can be overridden with the filter 'solr_power_customer_schema_file_path'.
 		*/
 
-		$schema = SOLR_POWER_PATH . '/schema.xml';
-		$upload_dir = wp_upload_dir();
-		$custom_schema_file_path = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
-
-		/**
-		 * Override the custom schema file path
-		 *
-		 * @param string $custom_schema_file_path The absolute path to a customer solr schema file.
-		 */
-		$custom_schema_file_path = apply_filters( 'solr_power_customer_schema_file_path', $custom_schema_file_path );
+		$custom_schema_file_path = self::custom_schema_file_path();
 
 		if ( file_exists( $custom_schema_file_path ) ) {
 			$schema = $custom_schema_file_path;

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -106,16 +106,25 @@ class SolrPower_Api {
 		/*
 		 * Solarium does not currently support submitting schemas to the server.
 		 * So we'll do it ourselves.
-		 * Let's check for a custom Schema.xml. It MUST be located in
-		 * wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml.
+		 * Let's check for a custom Schema.xml. It defaults to
+		 * wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml
+		 * and can be overridden with the filter 'solr_power_customer_schema_file_path'.
 		*/
 
 		$schema = SOLR_POWER_PATH . '/schema.xml';
 		$upload_dir = wp_upload_dir();
-		$custom_schema_file = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
-		if ( file_exists( $custom_schema_file ) ) {
+		$custom_schema_file_path = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
+
+		/**
+		 * Filter the custom schema file path
+		 *
+		 * @param string $custom_schema_file_path The default message.
+		 */
+		$custom_schema_file_path = apply_filters( 'solr_power_customer_schema_file_path', $custom_schema_file_path );
+
+		if ( file_exists( $custom_schema_file_path ) ) {
 			error_log( 'Solr Power: Uploading Schema from custom location' );
-			$schema = $custom_schema_file;
+			$schema = $custom_schema_file_path;
 		}
 
 		$path        = $this->compute_path();
@@ -162,7 +171,7 @@ class SolrPower_Api {
 		if ( 200 === (int) $curl_opts['http_code'] ) {
 			// Schema Upload Success.
 			$return_value = 'Schema Upload Success: ' . $curl_opts['http_code'];
-			if ( $schema == $custom_schema_file ) {
+			if ( $schema == $custom_schema_file_path ) {
 				$return_value = 'Custom ' . $return_value;
 			}
 			return $return_value;

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -160,7 +160,7 @@ class SolrPower_Api {
 		$curl_opts = curl_getinfo( $ch );
 		fclose( $file );
 		if ( 200 === (int) $curl_opts['http_code'] ) {
-			// Schema Upload Success
+			// Schema Upload Success.
 			$return_value = 'Schema Upload Success: ' . $curl_opts['http_code'];
 			if ( $schema == $custom_schema_file ) {
 				$return_value = 'Custom ' . $return_value;
@@ -168,7 +168,7 @@ class SolrPower_Api {
 			return $return_value;
 		}
 
-		// Schema Upload Failure
+		// Schema Upload Failure.
 		$return_value = 'Schema Upload Error: ' . $curl_opts['http_code'];
 		if ( preg_match( '#<h1>(HTTP Status [\d]+ - )?(.+)</h1>#', $response, $matches ) ) {
 			$return_value .= ' - ' . $matches[2];

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -116,9 +116,9 @@ class SolrPower_Api {
 		$custom_schema_file_path = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/schema.xml' );
 
 		/**
-		 * Filter the custom schema file path
+		 * Override the custom schema file path
 		 *
-		 * @param string $custom_schema_file_path The default message.
+		 * @param string $custom_schema_file_path The absolute path to a customer solr schema file.
 		 */
 		$custom_schema_file_path = apply_filters( 'solr_power_customer_schema_file_path', $custom_schema_file_path );
 

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -129,7 +129,8 @@ class SolrPower_Api {
 		 * wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml
 		 * and can be overridden with the filter 'solr_power_customer_schema_file_path'.
 		*/
-
+		
+		$schema = SOLR_POWER_PATH . '/schema.xml';
 		$custom_schema_file_path = self::custom_schema_file_path();
 
 		if ( file_exists( $custom_schema_file_path ) ) {
@@ -149,11 +150,11 @@ class SolrPower_Api {
 		}
 
 		if ( ! file_exists( $schema ) ) {
-			return $schema . ' does not exist.';
+			return "Schema '" . $schema . "' does not exist.";
 		}
 
 		if ( ! file_exists( $client_cert ) ) {
-			return $client_cert . ' does not exist.';
+			return "Client cert '" . $client_cert . "' does not exist.";
 		}
 
 		$file = fopen( $schema, 'r' );

--- a/includes/class-solrpower-api.php
+++ b/includes/class-solrpower-api.php
@@ -129,7 +129,7 @@ class SolrPower_Api {
 		 * wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml
 		 * and can be overridden with the filter 'solr_power_customer_schema_file_path'.
 		*/
-		
+
 		$schema = SOLR_POWER_PATH . '/schema.xml';
 		$custom_schema_file_path = self::custom_schema_file_path();
 

--- a/readme.txt
+++ b/readme.txt
@@ -226,7 +226,6 @@ Return:
 
 = Custom schema file path =
 
-
 By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path using the the `solr_power_customer_schema_file_path` filter.
 
 Parameters:

--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,14 @@ Return:
         return $enabled;
     }, 10, 2 );
 
+= Custom schema file path =
+
+By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path with the `solr_power_customer_schema_file_path` filter.
+
+    add_filter('solr_power_customer_schema_file_path', function($custom_schema_file_path) {
+        return '/absolute/path/to/schema.xml';
+    });
+
 = Common issues =
 
 * Failing to post the schema.xml will result in an error during indexing, "Missing `post_date_iso` field."

--- a/readme.txt
+++ b/readme.txt
@@ -267,7 +267,6 @@ Please report security bugs found in the source code of the Solr Power plugin th
 
 == Changelog ==
 
-
 = 2.6.0-dev =
 * Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://wordpress.org/support/users/sboisvert/))
 * Fixes custom schema file path for Composer Managed and other non-standard uploads directories. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,6 @@ Improve your user experience with the Apache Solr search engine for your WordPre
 
 == Description ==
 
-[![Travis Build Status](https://travis-ci.org/pantheon-systems/solr-power.svg?branch=master)](https://travis-ci.org/pantheon-systems/solr-power)
 [![Circle CI Build Status](https://circleci.com/gh/pantheon-systems/solr-power.svg?style=shield&circle-token=3af522a81a29eab25828a6b0d52e2f1afa7f044b)](https://circleci.com/gh/pantheon-systems/solr-power)
 
 Search is critical for your site, but the default search for WordPress leaves a lot to be desired. Improve your user experience with the Apache Solr search engine for your WordPress website.

--- a/readme.txt
+++ b/readme.txt
@@ -270,6 +270,8 @@ Please report security bugs found in the source code of the Solr Power plugin th
 
 = 2.6.0-dev =
 * Adds `is_solr_query` filter [[#588](https://github.com/pantheon-systems/solr-power/pull/588)] (props [@sboisvert](https://wordpress.org/support/users/sboisvert/))
+* Fixes custom schema file path for Composer Managed and other non-standard uploads directories. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
+* Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file. [[#637](https://github.com/pantheon-systems/solr-power/pull/637)]
 
 = 2.5.3 (April 24, 2024) =
 * Fixes a very old bug that would cause tax queries to be built incorrectly. [[#622](https://github.com/pantheon-systems/solr-power/pull/622)] (props [@offshorealert](https://wordpress.org/support/users/offshorealert/))

--- a/readme.txt
+++ b/readme.txt
@@ -226,7 +226,14 @@ Return:
 
 = Custom schema file path =
 
-By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path with the `solr_power_customer_schema_file_path` filter.
+
+By default, custom schema is sourced from `wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml`. This can be overridden with an absolute path using the the `solr_power_customer_schema_file_path` filter.
+
+Parameters:
+* $custom_schema_file_path (string): Default path to a custom schema file
+
+Return:
+* string: Absolute path to a custom schema.xml file.
 
     add_filter('solr_power_customer_schema_file_path', function($custom_schema_file_path) {
         return '/absolute/path/to/schema.xml';

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -18,4 +18,4 @@ Feature: Solr Power plugin
 
   Scenario: I see the default schema path in the action dashboard
     When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
-    Then I should see "To use a custom schema.xml, upload it to the /code/wp-content/uploads/solr-for-wordpress-on-pantheon/ directory."
+    Then I should see "To use a custom schema.xml, upload it to the /code/wp-content/uploads/solr-for-wordpress-on-pantheon directory."

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -10,3 +10,8 @@ Feature: Solr Power plugin
   Scenario: Solr is available
     When I go to "/wp-admin/options-general.php?page=solr-power"
     When I should see "Successful" in the "#solr_info" element
+
+  Scenario: I can submit default schema
+    Given I am on /wp-admin/admin.php?page=solr-power#top#solr_action
+    When I press "s4wp_repost_schema"
+    Then I should see "Schema Upload Success: 200"

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -11,6 +11,10 @@ Feature: Solr Power plugin
     When I go to "/wp-admin/options-general.php?page=solr-power"
     When I should see "Successful" in the "#solr_info" element
 
+  Scenario: I see the default schema path in the action dashboard
+    When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
+    Then I should see "To use a custom schema.xml, upload it to the /code/wp-content/uploads/solr-for-wordpress-on-pantheon/ directory." in the "#solr_action" element
+
   Scenario: I can submit default schema
     When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
     And I press "s4wp_repost_schema"

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -12,6 +12,6 @@ Feature: Solr Power plugin
     When I should see "Successful" in the "#solr_info" element
 
   Scenario: I can submit default schema
-    Given I am on /wp-admin/admin.php?page=solr-power#top#solr_action
-    When I press "s4wp_repost_schema"
+    When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
+    And I press "s4wp_repost_schema"
     Then I should see "Schema Upload Success: 200" in the "#message" element

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -14,4 +14,4 @@ Feature: Solr Power plugin
   Scenario: I can submit default schema
     Given I am on /wp-admin/admin.php?page=solr-power#top#solr_action
     When I press "s4wp_repost_schema"
-    Then I should see "Schema Upload Success: 200"
+    Then I should see "Schema Upload Success: 200" in the "#message" element

--- a/tests/behat/solr-power.feature
+++ b/tests/behat/solr-power.feature
@@ -11,11 +11,11 @@ Feature: Solr Power plugin
     When I go to "/wp-admin/options-general.php?page=solr-power"
     When I should see "Successful" in the "#solr_info" element
 
-  Scenario: I see the default schema path in the action dashboard
-    When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
-    Then I should see "To use a custom schema.xml, upload it to the /code/wp-content/uploads/solr-for-wordpress-on-pantheon/ directory." in the "#solr_action" element
-
   Scenario: I can submit default schema
     When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
     And I press "s4wp_repost_schema"
     Then I should see "Schema Upload Success: 200" in the "#message" element
+
+  Scenario: I see the default schema path in the action dashboard
+    When I go to "/wp-admin/admin.php?page=solr-power#top#solr_action"
+    Then I should see "To use a custom schema.xml, upload it to the /code/wp-content/uploads/solr-for-wordpress-on-pantheon/ directory."

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -593,22 +593,14 @@ EOT;
 		$this->assertContains($expected, $actual);
 	}
 
-	public function test_custom_schema_file_path_wp_content_moved() {
-		define( 'UPLOADS', trailingslashit( WP_CONTENT_DIR ) . 'files' );
-		$expected = "wp-content/files/solr-for-wordpress-on-pantheon/schema.xml";
-		$actual = SolrPower_Api::custom_schema_file_path();
-
-		$this->assertContains($expected, $actual);
-	}
-
 	public function test_custom_schema_file_path_with_filter() {
-		$expected = "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml";
 		add_filter(
 			'solr_power_customer_schema_file_path',
 			function( $custom_schema_file_path ) {
-				return $expected;
+				return "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml";
 			},
 		);
+		$expected = "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml";
 		$actual = SolrPower_Api::custom_schema_file_path();
 
 		$this->assertEquals($expected, $actual);

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -588,7 +588,7 @@ EOT;
 
 	public function test_custom_schema_file_path_default() {
 		$expected = "wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml";
-		$actual = SolrPower_Sync::custom_schema_file_path();
+		$actual = SolrPower_Api::custom_schema_file_path();
 		
 		$this->assertContains($expected, $actual);
 	}
@@ -596,7 +596,7 @@ EOT;
 	public function test_custom_schema_file_path_wp_content_moved() {
 		define( 'UPLOADS', trailingslashit( WP_CONTENT_DIR ) . 'files' );
 		$expected = "wp-content/files/solr-for-wordpress-on-pantheon/schema.xml";
-		$actual = SolrPower_Sync::custom_schema_file_path();
+		$actual = SolrPower_Api::custom_schema_file_path();
 
 		$this->assertContains($expected, $actual);
 	}
@@ -609,7 +609,7 @@ EOT;
 				return $expected;
 			},
 		);
-		$actual = SolrPower_Sync::custom_schema_file_path();
+		$actual = SolrPower_Api::custom_schema_file_path();
 
 		$this->assertEquals($expected, $actual);
 	}

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -586,4 +586,31 @@ EOT;
 		$this->assertContains( 'This text has treatment keyword in ACF', $query->posts[0]->post_content );
 	}
 
+	public function test_custom_schema_file_path_default() {
+		$expected = "wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml"
+		$actual = SolrPower_Sync::custom_schema_file_path();
+		
+		$this->assertContains($expected, $actual);
+	}
+
+	public function test_custom_schema_file_path_wp_content_moved() {
+		define( 'UPLOADS', trailingslashit( WP_CONTENT_DIR ) . 'files' );
+		$expected = "wp-content/files/solr-for-wordpress-on-pantheon/schema.xml"
+		$actual = SolrPower_Sync::custom_schema_file_path();
+
+		$this->assertContains($expected, $actual);
+	}
+
+	public function test_custom_schema_file_path_with_filter() {
+		$expected = "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml"
+		add_filter(
+			'solr_power_customer_schema_file_path',
+			function( $custom_schema_file_path ) {
+				return $expected;
+			},
+		);
+		$actual = SolrPower_Sync::custom_schema_file_path();
+
+		$this->assertEquals($expected, $actual);
+	}
 }

--- a/tests/phpunit/test-solr.php
+++ b/tests/phpunit/test-solr.php
@@ -587,7 +587,7 @@ EOT;
 	}
 
 	public function test_custom_schema_file_path_default() {
-		$expected = "wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml"
+		$expected = "wp-content/uploads/solr-for-wordpress-on-pantheon/schema.xml";
 		$actual = SolrPower_Sync::custom_schema_file_path();
 		
 		$this->assertContains($expected, $actual);
@@ -595,14 +595,14 @@ EOT;
 
 	public function test_custom_schema_file_path_wp_content_moved() {
 		define( 'UPLOADS', trailingslashit( WP_CONTENT_DIR ) . 'files' );
-		$expected = "wp-content/files/solr-for-wordpress-on-pantheon/schema.xml"
+		$expected = "wp-content/files/solr-for-wordpress-on-pantheon/schema.xml";
 		$actual = SolrPower_Sync::custom_schema_file_path();
 
 		$this->assertContains($expected, $actual);
 	}
 
 	public function test_custom_schema_file_path_with_filter() {
-		$expected = "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml"
+		$expected = "/code/wp-content/solr-for-wordpress-elsewhere-on-pantheon/schema.xml";
 		add_filter(
 			'solr_power_customer_schema_file_path',
 			function( $custom_schema_file_path ) {

--- a/views/options/action.php
+++ b/views/options/action.php
@@ -52,8 +52,7 @@
 				</tr>
 				<tr valign="top">
 					<?php
-					$upload_dir = wp_upload_dir();
-					$dir = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/' );
+					$dir = dirname( SolrPower_Api::custom_schema_file_path() );
 					?>
 					<td scope="row" colspan="2">To use a custom schema.xml, upload it to the
 						<b><?php echo esc_html( $dir ); ?></b>

--- a/views/options/action.php
+++ b/views/options/action.php
@@ -52,14 +52,8 @@
 				</tr>
 				<tr valign="top">
 					<?php
-					if ( ! empty( $_ENV['FILEMOUNT'] ) ) {
-						$dir = realpath( ABSPATH ) . '/' . $_ENV['FILEMOUNT'] . '/solr-for-wordpress-on-pantheon/';
-					} else {
-						$upload_dir = wp_upload_dir();
-						$base_dir   = $upload_dir['basedir'];
-						$base_dir   = str_replace( ABSPATH, '/', $base_dir );
-						$dir        = $base_dir . '/solr-for-wordpress-on-pantheon/';
-					}
+					$upload_dir = wp_upload_dir();
+					$dir = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/');
 					?>
 					<td scope="row" colspan="2">To use a custom schema.xml, upload it to the
 						<b><?php echo esc_html( $dir ); ?></b>

--- a/views/options/action.php
+++ b/views/options/action.php
@@ -53,7 +53,7 @@
 				<tr valign="top">
 					<?php
 					$upload_dir = wp_upload_dir();
-					$dir = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/');
+					$dir = path_join( $upload_dir['basedir'], 'solr-for-wordpress-on-pantheon/' );
 					?>
 					<td scope="row" colspan="2">To use a custom schema.xml, upload it to the
 						<b><?php echo esc_html( $dir ); ?></b>


### PR DESCRIPTION
Plugin's path check did not take into account upload dir being adjusted as seen in composer managed sites.

* Fixes custom schema file path for Composer Managed and other non-standard uploads directories.
* Adds filter `solr_power_customer_schema_file_path` to specify an alternative custom schema.xml file.
* `wp solr repost-schema` specifies if the custom schema was posted.
* Bump 'tested up to'