### PR TITLE
reverse fixture version logic

### DIFF
--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -32,8 +32,8 @@ main(){
     FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
     echo "Fixture Version: ${FIXTURE_VERSION}"
 
-    if ! php -r "exit(version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}'));"; then
-        echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"
+    if ! php -r "exit(version_compare('${FIXTURE_VERSION}', '${TESTED_UP_TO}'));"; then
+        echo "'Fixture Version' ${FIXTURE_VERSION} is less than 'Tested up to' ${TESTED_UP_TO}"
         echo "Please update ${TERMINUS_SITE} to at least WordPress ${TESTED_UP_TO}"
         exit 1
     fi


### PR DESCRIPTION
"validate-fixture-version.sh" has the wrong details when failing