### PR TITLE
Use build-tag-release action

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -1,45 +1,24 @@
-name: Build and Tag
+name: Build, Tag, and Release
 on:
   push:
     branches:
       - 'main'
 
 permissions:
+  pull-requests: write
   contents: write
 
 jobs:
-  wordpress:
-    name: Release
+  tag:
+    name: Tag and Release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
-
-    - name: install node v12
-      uses: actions/setup-node@v3
+      uses: actions/checkout@v4
+    - name: Build, tag, and release
+      uses: pantheon-systems/plugin-release-actions/build-tag-release@v0
       with:
-        node-version: 12
-
-    - name: Build
-      run: |
-        npm ci
-        npm run build
-        composer install --no-dev -o
-
-    - name: Setup
-      run: 'echo "VERSION=$(jq -r .version ./package.json)" >> $GITHUB_ENV'
-
-    - name: Tag
-      run: |
-        echo "Releasing version $VERSION ..."
-        git config user.name Pantheon Automation
-        git config user.email bot@getpantheon.com
-        git checkout -b "release-$VERSION"
-        git add -f assets/* vendor/
-        git commit -m "Release $VERSION"
-        git tag "$VERSION"
-        git push --tags
-        gh release create "$VERSION" -t "$VERSION" --generate-notes -d
-      env:
-        TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GH_TOKEN: ${{ github.token }}
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+        build_node_assets: "true"
+        build_composer_assets: "true"
+        draft: "true"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `main`. Your PR should consist of all commits to `develop` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
 1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `main`. "merge" is preferred in this case, not rebase. _Never_ squash to `main`.
-1. Pull `main` locally, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
-1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
-1. Create a [new release](https://github.com/pantheon-systems/solr-power/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.
+1. CI will build, tag and draft [a release](https://github.com/pantheon-systems/solr-power/releases/).
+1. Review the drafted release, updating release notes if needed, confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
+1. Publish the drafted release.
 1. Wait for the [_Release solr-power plugin to wp.org_ action](https://github.com/pantheon-systems/solr-power/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/solr-power/). This may take a few minutes.
 1. Following the release, prepare the next dev version with the following steps:


### PR DESCRIPTION
Implements build/tag/release https://github.com/pantheon-systems/plugin-release-actions/ in the OG problem repo.

Not working on prepare-dev or release-pr at the moment