### PR TITLE
fix(VUL-23981): bump websocket-driver from 0.7.4 to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2557,10 +2557,11 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -4439,9 +4440,9 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "requires": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Summary

Bumps transitive dependency `websocket-driver` from **0.7.4** to **0.7.5** to address a critical CVE.

Jira ticket: [VUL-23981](https://getpantheon.atlassian.net/browse/VUL-23981)

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---------|-----|----------|-------------|----------|
| websocket-driver | [CVE-2026-54466](https://nvd.nist.gov/vuln/detail/CVE-2026-54466) | Critical | Message corruption via abuse of protocol length headers (CWE-130) | 0.7.5 |

## Changes

`websocket-driver` is a **transitive** dependency — it is not listed in `package.json` directly. The dependency chain is:

```
grunt-contrib-watch -> tiny-lr -> faye-websocket -> websocket-driver
```

Only `package-lock.json` was modified to pin `websocket-driver` to 0.7.5. The package was not added to `package.json` as a direct dependency.

## CVE Attribution

CVE-2026-54466 affects `websocket-driver < 0.7.5` (npm). The package is confirmed present in this project's lockfile at 0.7.4. The fix is to upgrade to ≥ 0.7.5.

[VUL-23981]: https://getpantheon.atlassian.net/browse/VUL-23981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ