### PR TITLE
fix(VUL-24442): bump brace-expansion to 1.1.16 and js-yaml to 3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -415,10 +415,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1746,10 +1747,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2804,9 +2806,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -3266,7 +3268,7 @@
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
+        "js-yaml": "3.15.0",
         "minimatch": "~3.0.4",
         "nopt": "~3.0.6"
       }
@@ -3833,9 +3835,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "readme": "grunt readme",
     "watch": "grunt watch"
   },
+  "overrides": {
+    "js-yaml": "3.15.0"
+  },
   "devDependencies": {
     "grunt": "^1.6.1",
     "grunt-autoprefixer": "~3.0.4",


### PR DESCRIPTION
## Summary

Bumps two transitive npm devDependencies to patch high-severity DoS vulnerabilities reported in [VUL-24442](https://getpantheon.atlassian.net/browse/VUL-24442).

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---------|-----|----------|-------------|----------|
| brace-expansion | [CVE-2026-13149](https://nvd.nist.gov/vuln/detail/CVE-2026-13149) | High | DoS via exponential-time expansion of consecutive non-expanding `{}` groups | 1.1.16 |
| js-yaml | [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869) | High | YAML merge-key chains force quadratic CPU consumption | 3.15.0 |

## Changes

- **package-lock.json:** Updated lockfile — both packages are transitive devDependencies (brace-expansion via minimatch→glob/grunt; js-yaml via grunt).
- **package.json:** Added an `overrides` entry to force `js-yaml` to `3.15.0`. This was necessary because `grunt@1.6.2` (latest available) declares `js-yaml ~3.14.0`, which cannot be resolved to `>= 3.15.0` via a normal `npm update`. The override applies only to devDependencies and does not affect production runtime behaviour.

## CVE Attribution

Both packages are devDependencies only — they are used by Grunt build tooling and are not included in the WordPress plugin's distributed code. Risk is limited to CI/development environments.

[VUL-24442]: https://getpantheon.atlassian.net/browse/VUL-24442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ