### PR TITLE
ci(SITE-5995): add wporg-validator.yml using plugin-check-action

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,50 @@
+name: WP.org Validator
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - name: Setup PHP 8.4
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      with:
+        php-version: "8.4"
+        extensions: mysqli
+        tools: composer,wp-cli
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+      with:
+        path: |
+            ~/.composer/cache
+            vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --no-dev --no-interaction --no-progress --prefer-dist --no-scripts --no-ansi
+
+    - name: Create Dist Archive for wp.org validation
+      env:
+        COMPOSER_AUTH: '{"github-oauth": {}}'
+      run: |
+        rm -f ~/.composer/auth.json
+        wp package install wp-cli/dist-archive-command:v3.1.0
+        wp dist-archive . --plugin-dirname=solr-power --filename-format=solr-power-dist
+        unzip ../solr-power-dist.zip
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # 1.1.5
+      with:
+        build-dir: solr-power

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: library
   lifecycle: mature
-  owner: site
+  owner: site-experience


### PR DESCRIPTION
## Summary

- Adds `wporg-validator.yml` workflow using `wordpress/plugin-check-action@1.1.5` (SHA-pinned)
- Runs on `pull_request` and `push` to `main`
- Includes COMPOSER_AUTH fix (`env: COMPOSER_AUTH: '{"github-oauth": {}}'` + `rm -f ~/.composer/auth.json`) to avoid `shivammathur/setup-php` writing an invalid `ghs_*` token to `~/.composer/auth.json`
- Pins `wp-cli/dist-archive-command:v3.1.0`

## Context

[SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)

`pantheon-systems/action-wporg-validator` is deprecated. solr-power never had any validator. This PR adds net-new plugin-check validation following the pattern established across other Pantheon WP plugins (wp-saml-auth, PAPC, wp-native-php-sessions).

A follow-up compliance PR will fix any ERRORs surfaced by the first CI run.

## Test plan

- [ ] CI runs and produces plugin-check output (pass or fail with specific error codes)
- [ ] No `COMPOSER_AUTH` errors in dist-archive step

[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ