### PR TITLE
fix(deps): [VUL-24442 et al] npm security bumps + guzzle/psr7 audit-ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": [
+                "GHSA-g446-98w2-8p5w",
+                "GHSA-c2w2-prh8-qm98"
+            ]
         }
     },
     "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -415,10 +415,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1585,10 +1586,11 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
-      "dev": true
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1746,10 +1748,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2557,10 +2560,11 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -2804,9 +2808,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -3266,7 +3270,7 @@
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
+        "js-yaml": "3.15.0",
         "minimatch": "~3.0.4",
         "nopt": "~3.0.6"
       }
@@ -3702,9 +3706,9 @@
       }
     },
     "immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true
     },
     "inflight": {
@@ -3833,9 +3837,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4439,9 +4443,9 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
       "requires": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "grunt-sass": "~3.1.0",
     "grunt-wp-readme-to-markdown": "~2.1.0",
     "sass": "^1.82.0"
+  },
+  "overrides": {
+    "js-yaml": "3.15.0"
   }
 }


### PR DESCRIPTION
<!-- PR title: fix(deps): [VUL-24442 et al] npm security bumps + guzzle/psr7 audit-ignore -->

## Summary

| Package | Was | Now | Ticket | Route |
|---------|-----|-----|--------|-------|
| brace-expansion | 1.1.11 | 1.1.17 | VUL-24442 | npm update (lockfile; minimatch `^1.1.7` allows) |
| js-yaml | 3.14.1 | 3.15.0 | VUL-24442 | override in package.json (grunt pins `~3.14.0`) |
| immutable | 5.0.3 | 5.1.9 | VUL-25001, VUL-25002 | npm update (lockfile; sass `^5.0.2` allows) |
| websocket-driver | 0.7.4 | 0.7.5 | VUL-23981 | npm update (lockfile; faye-websocket `>=0.5.1` allows) |
| guzzlehttp/guzzle | 6.5.8 | 6.5.8 (no change) | VUL-24495 | audit-ignore GHSA-g446-98w2-8p5w (dev-only) |
| guzzlehttp/psr7 | 1.9.1 | 1.9.1 (no change) | VUL-25207 | audit-ignore GHSA-c2w2-prh8-qm98 (dev-only) |

## Release

**No release required.** Nothing in this PR changes what ships to installed sites. All four npm bumps are transitive devDependencies of the Grunt build toolchain (`dependencies` is empty in package.json), and the composer change only adds audit-ignore metadata for packages that live in `packages-dev`. The production runtime (`solarium/solarium` + `symfony/event-dispatcher`) is untouched. Full evidence in the classification section below.

## Context

- [VUL-24442](https://getpantheon.atlassian.net/browse/VUL-24442): brace-expansion CVE-2026-13149 + js-yaml CVE-2026-59869
- [VUL-24495](https://getpantheon.atlassian.net/browse/VUL-24495): guzzlehttp/guzzle CVE-2026-59883
- [VUL-25001](https://getpantheon.atlassian.net/browse/VUL-25001): immutable CVE-2026-59879
- [VUL-25002](https://getpantheon.atlassian.net/browse/VUL-25002): immutable CVE-2026-59880
- [VUL-25207](https://getpantheon.atlassian.net/browse/VUL-25207): guzzlehttp/psr7 CVE-2026-59882
- [VUL-23981](https://getpantheon.atlassian.net/browse/VUL-23981): websocket-driver CVE-2026-54466

Samwise previously opened separate PRs for subsets of these: #655 (websocket-driver, approved by Asim), #656 (brace-expansion + js-yaml, approved by Asim, needs 1 more reviewer), and pushed fixes to Dependabot PR #654 (immutable). This branch consolidates all six tickets into one PR off current main.

### False positives

None. All five npm CVEs were confirmed real against the installed versions:
- brace-expansion 1.1.11 is in range `< 1.1.16` (CVE-2026-13149 1.x floor is 1.1.16)
- js-yaml 3.14.1 is in range `>= 3.0.0, < 3.15.0` (CVE-2026-59869)
- immutable 5.0.3 is in range `>= 5.0.0-beta.1, < 5.1.8` (CVE-2026-59879 and CVE-2026-59880, both fixed at 5.1.8)
- websocket-driver 0.7.4 is in range `< 0.7.5` (CVE-2026-54466)

### Advisory ranges enumerated (from GitHub API)

| Package | Advisory | CVE | Ranges |
|---------|----------|-----|--------|
| brace-expansion | GHSA-3jxr-9vmj-r5cp | CVE-2026-13149 | `< 1.1.16` (1.x) / `>= 2.0.0, < 2.1.2` (2.x) / `>= 3.0.0, < 5.0.7` (3-4.x) |
| js-yaml | GHSA-52cp-r559-cp3m | CVE-2026-59869 | `>= 3.0.0, < 3.15.0` (3.x) / `>= 4.0.0, < 4.3.0` (4.x) |
| immutable | GHSA-v56q-mh7h-f735 | CVE-2026-59879 | `< 4.3.9` (4.x) / `>= 5.0.0-beta.1, < 5.1.8` (5.x) |
| immutable | GHSA-xvcm-6775-5m9r | CVE-2026-59880 | `< 4.3.9` (4.x) / `>= 5.0.0-beta.1, < 5.1.8` (5.x) |
| websocket-driver | GHSA-xv26-6w52-cph6 | CVE-2026-54466 | `< 0.7.5` |
| guzzlehttp/guzzle | GHSA-g446-98w2-8p5w | CVE-2026-59883 | `< 7.12.3` |
| guzzlehttp/psr7 | GHSA-c2w2-prh8-qm98 | CVE-2026-59882 | `< 2.12.3` |

## Production dependency classification

**All six findings are dev-only. No production code changes.**

### npm (all devDependencies)

All four npm packages are transitive devDependencies within the Grunt build toolchain. They are not bundled into the distributed WordPress plugin ZIP. Dependency chains:

- brace-expansion: minimatch (`^1.1.7`) -> brace-expansion
- js-yaml: grunt (`~3.14.0`) -> js-yaml
- immutable: sass (`^5.0.2`) -> immutable
- websocket-driver: faye-websocket (`>=0.5.1`) -> websocket-driver

### PHP / composer (audit-ignore route)

`guzzlehttp/guzzle` 6.5.8 and `guzzlehttp/psr7` 1.9.1 are in `packages-dev` only. Verified from `composer.lock`:

**Chain:** `require-dev` -> `pantheon-wordpress-upstream-tests` -> `behat/mink-goutte-driver` -> `fabpot/goutte` -> `guzzlehttp/guzzle ^6.0` -> `guzzlehttp/psr7 ^1.9`

**solarium/solarium** (the only production Solr client, `packages` section, v4.2.0): its runtime `require` is `php: ^7.0` and `symfony/event-dispatcher: ^2.7 || ^3.0 || ^4.0` only. Guzzle appears in solarium's `require-dev` (for its own tests) but NOT in its `require`. Solarium v4 does not require guzzle at runtime.

No production upgrade path exists: guzzle 7.x requires PHP >= 7.2.5; the project platform is pinned to PHP 7.1. Remediation would require raising the PHP platform, upgrading solarium to 5.x/6.x, and upgrading the entire Behat test stack. Out of scope for a security-only patch.

Audit-ignore entries added to `composer.json` under `config.audit.ignore` (GHSA IDs per Composer house style), referencing VUL-24495 and VUL-25207.

## Test plan

- [ ] `npm audit` shows all five target GHSAs clear: GHSA-3jxr-9vmj-r5cp, GHSA-52cp-r559-cp3m, GHSA-v56q-mh7h-f735, GHSA-xvcm-6775-5m9r, GHSA-xv26-6w52-cph6
- [ ] `npm run build` passes (grunt jshint, uglify, sass, autoprefixer, cssmin)
- [ ] `composer audit --locked` shows guzzle and psr7 in "ignored" section
- [ ] No changes to `composer.lock` (only `composer.json` edited)
- [ ] Version floors met: brace-expansion >= 1.1.16, js-yaml >= 3.15.0, immutable >= 5.1.8, websocket-driver >= 0.7.5


[VUL-24442]: https://getpantheon.atlassian.net/browse/VUL-24442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-24495]: https://getpantheon.atlassian.net/browse/VUL-24495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-25001]: https://getpantheon.atlassian.net/browse/VUL-25001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
