### PR TITLE
ci(validator): [SITE-5995] Add wporg-validator.yml to main

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,50 @@
+name: WP.org Validator
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - name: Setup PHP 8.4
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      with:
+        php-version: "8.4"
+        extensions: mysqli
+        tools: composer,wp-cli
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+      with:
+        path: |
+            ~/.composer/cache
+            vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --no-dev --no-interaction --no-progress --prefer-dist --no-scripts --no-ansi
+
+    - name: Create Dist Archive for wp.org validation
+      env:
+        COMPOSER_AUTH: '{"github-oauth": {}}'
+      run: |
+        rm -f ~/.composer/auth.json
+        wp package install wp-cli/dist-archive-command:v3.1.0
+        wp dist-archive . --plugin-dirname=solr-power --filename-format=solr-power-dist
+        unzip ../solr-power-dist.zip
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # 1.1.5
+      with:
+        build-dir: solr-power


### PR DESCRIPTION
## Summary

- Add `.github/workflows/wporg-validator.yml` to `main`, running `wordpress/plugin-check-action@6f5a57e` (1.1.5) against a `wp dist-archive` build.
- Cherry-pick of `dc70ec2` from `develop` (merged there via #657). Byte-identical to develop's copy, so it will not conflict with a later `develop` promotion.

## Context

[SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)

The migration off `pantheon-systems/action-wporg-validator` landed on `develop` only. `main` is the default branch, so today no plugin-check validation runs on pushes to the branch that ships. This closes that gap.

## Known red CI on this PR

The `Validate Plugin` job will fail here, because `main` does not yet carry the compliance fixes:

- `readme.txt` has `Tested up to: 6.7.1`, which trips `outdated_tested_upto_header` (an ERROR, not a warning). `develop` is already at `7.0`.
- 12 `WordPress.Security.EscapeOutput.OutputNotEscaped` ERRORs across `template/s4w_search.php`, `template/s4wp_search.php`, `includes/legacy-functions.php`, and `includes/class-solrpower-sync.php`. Fixes are in #658, still open against `develop`.

So this PR should merge only after #658 lands on `develop` and `develop` is promoted to `main`. At that point the fixes are on `main` and this job goes green. An alternative is to skip this PR entirely and let the `develop` promotion carry the workflow along with the fixes in one shot.

## Test plan

- [ ] After #658 merges and `develop` promotes to `main`, rerun `Validate Plugin` and confirm 0 ERRORs

## References

- Jira: [SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)
- Migration PR: pantheon-systems/solr-power#657
- Compliance PR: pantheon-systems/solr-power#658

[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ