### PR TITLE
fix(VUL-26008): bump postcss to 8.5.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -321,15 +321,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
@@ -685,12 +676,6 @@
       "dependencies": {
         "string-template": "~0.2.1"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw==",
-      "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -1739,12 +1724,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
-      "dev": true
-    },
     "node_modules/js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -1971,6 +1950,25 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -2150,6 +2148,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2172,26 +2177,32 @@
       }
     },
     "node_modules/postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha512-aAutxE8MvL1bHylFMYb2c2nniFax8XDztHzZ+x5DVsNJnoW6VHvGSNSqdW3+ip255HCWfPjayVVFzMmyiL7opA==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
-      }
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pretty-bytes": {
@@ -2725,12 +2736,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true
-    },
     "ansi-regex": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
@@ -2782,7 +2787,7 @@
         "browserslist": "~0.4.0",
         "caniuse-db": "^1.0.30000214",
         "num2fraction": "^1.1.0",
-        "postcss": "~4.1.12"
+        "postcss": "8.5.12"
       }
     },
     "balanced-match": {
@@ -3027,12 +3032,6 @@
       "requires": {
         "string-template": "~0.2.1"
       }
-    },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw==",
-      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3280,7 +3279,7 @@
         "autoprefixer-core": "^5.1.7",
         "chalk": "~1.0.0",
         "diff": "~1.3.0",
-        "postcss": "^4.1.11"
+        "postcss": "8.5.12"
       }
     },
     "grunt-cli": {
@@ -3826,12 +3825,6 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
-    "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
-      "dev": true
-    },
     "js-yaml": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -4008,6 +4001,12 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true
+    },
     "node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
@@ -4148,6 +4147,12 @@
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4161,25 +4166,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha512-aAutxE8MvL1bHylFMYb2c2nniFax8XDztHzZ+x5DVsNJnoW6VHvGSNSqdW3+ip255HCWfPjayVVFzMmyiL7opA==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "requires": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
     },
     "pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "readme": "grunt readme",
     "watch": "grunt watch"
   },
+  "overrides": {
+    "postcss": "8.5.12"
+  },
   "devDependencies": {
     "grunt": "^1.6.1",
     "grunt-autoprefixer": "~3.0.4",


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry to force `postcss` to `8.5.12` across the dependency tree, resolving CVE-2026-45623 in the lockfile.

Addresses: [VUL-26008](https://getpantheon.atlassian.net/browse/VUL-26008)

---

## CVE table

| Package | CVE | Severity | Description | Fixed in |
|---|---|---|---|---|
| postcss | [CVE-2026-45623](https://github.com/advisories/GHSA-6g55-p6wh-862q) | High (7.5) | Arbitrary file read and information disclosure via attacker-controlled `sourceMappingURL` in CSS comments — attacker-supplied path in a CSS comment is read from disk by `PreviousMap.loadFile()` with no sanitisation, leaking the first ~10 bytes of the file via a `JSON.parse` SyntaxError message | 8.5.12 |

---

## Changes

- **`package.json`** — added `"overrides": { "postcss": "8.5.12" }`. `postcss` is a transitive dependency of `grunt-autoprefixer` (via `autoprefixer-core`), both of which pin to postcss v4.x (`~4.1.12` / `^4.1.11`). Those packages have no releases that use postcss v8, so a direct lockfile-only bump is not possible. The npm `overrides` mechanism forces the resolved version to 8.5.12 in the lockfile without modifying the parent package pins.
- **`package-lock.json`** — updated from postcss `4.1.16` to `8.5.12`.

### CVE attribution

PostCSS v4.1.16 contains the identical vulnerable code path (`lib/previous-map.js` performs unsanitised `readFileSync` on the `sourceMappingURL` annotation) as the versions explicitly cited in the advisory (`<= 8.5.11`). The advisory range uses `<= 8.5.11` in the v8.x context, but v4.x is also affected. This is confirmed: postcss is a dev/build-time dependency only (used by `grunt-autoprefixer` to process CSS during builds); it is not imported by the plugin's PHP/JS runtime code. The attack surface is limited to build environments that process attacker-controlled CSS, not production user requests.

---

## Risk assessment

**High** — major-version bump (v4 → v8) of a build-tool transitive dependency in a repo with infrequent releases and no observable staging layer. However, postcss is build-time only (not imported by the plugin at runtime), so a regression would surface as a failed CSS build step in CI rather than a production incident.

| Layer | Score | Evidence |
|---|---|---|
| Pre-merge detection | partial | 9 PHP test files; `lint` + `test-phpunit` + `test-behat` jobs in CI on PRs; no JS/build tests found |
| Deployment safety | unknown | No staging env visible in repo; WordPress plugin released as a zip |
| Production detection | unknown | WordPress plugin; observability lives outside repo |
| Recovery speed | weak | Last release Dec 2024 (18+ months ago); no release-please |

Bump: `postcss` `4.1.16` → `8.5.12` (major — v4 → v8 series).


[VUL-26008]: https://getpantheon.atlassian.net/browse/VUL-26008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ