### PR TITLE
fix(deps): [VUL-26008 et al, SITE-5995] promote dev-dep security fixes + wporg-validator workflow to main [ci skip]

### DIFF
--- a/.github/workflows/wporg-validator.yml
+++ b/.github/workflows/wporg-validator.yml
@@ -1,0 +1,50 @@
+name: WP.org Validator
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Plugin
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+    - name: Setup PHP 8.4
+      uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # v2
+      with:
+        php-version: "8.4"
+        extensions: mysqli
+        tools: composer,wp-cli
+
+    - name: Cache Composer dependencies
+      uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+      with:
+        path: |
+            ~/.composer/cache
+            vendor
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+            ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --no-dev --no-interaction --no-progress --prefer-dist --no-scripts --no-ansi
+
+    - name: Create Dist Archive for wp.org validation
+      env:
+        COMPOSER_AUTH: '{"github-oauth": {}}'
+      run: |
+        rm -f ~/.composer/auth.json
+        wp package install wp-cli/dist-archive-command:v3.1.0
+        wp dist-archive . --plugin-dirname=solr-power --filename-format=solr-power-dist
+        unzip ../solr-power-dist.zip
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # 1.1.5
+      with:
+        build-dir: solr-power

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,11 +63,11 @@ module.exports = function( grunt ) {
       /**
        * Auto-prefix CSS Elements after SASS is processed.
        */
-      autoprefixer : {
+      postcss : {
 
           options : {
-              browsers : ['last 5 versions'],
-              map      : true
+              map        : true,
+              processors : [ require( 'autoprefixer' )() ]
           },
 
           files : {
@@ -146,7 +146,7 @@ module.exports = function( grunt ) {
                   'assets/css/scss/*'
               ],
 
-              tasks : ['sass', 'autoprefixer', 'cssmin']
+              tasks : ['sass', 'postcss', 'cssmin']
 
           }
       },
@@ -159,10 +159,10 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-uglify' );
 	grunt.loadNpmTasks( 'grunt-sass' );
 	grunt.loadNpmTasks( 'grunt-contrib-cssmin' );
-	grunt.loadNpmTasks( 'grunt-autoprefixer' );
+	grunt.loadNpmTasks( '@lodder/grunt-postcss' );
 	grunt.loadNpmTasks( 'grunt-contrib-watch' );
 	grunt.registerTask( 'readme', ['wp_readme_to_markdown']);
-	grunt.registerTask( 'default', ['jshint', 'uglify:backend','uglify:frontend', 'sass', 'autoprefixer', 'cssmin'] );
+	grunt.registerTask( 'default', ['jshint', 'uglify:backend','uglify:frontend', 'sass', 'postcss', 'cssmin'] );
 
 	grunt.util.linefeed = '\n';
 

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,12 @@
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "ignore": [
+                "GHSA-g446-98w2-8p5w",
+                "GHSA-c2w2-prh8-qm98"
+            ]
         }
     },
     "require": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,46 @@
       "name": "solr-power",
       "version": "2.6.0",
       "devDependencies": {
+        "@lodder/grunt-postcss": "^3.1.1",
+        "autoprefixer": "^10.5.4",
         "grunt": "^1.6.1",
-        "grunt-autoprefixer": "~3.0.4",
         "grunt-contrib-cssmin": "^5.0.0",
         "grunt-contrib-jshint": "^3.2.0",
         "grunt-contrib-uglify": "~5.2.2",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-sass": "~3.1.0",
         "grunt-wp-readme-to-markdown": "~2.1.0",
+        "postcss": "^8.5.23",
         "sass": "^1.82.0"
+      }
+    },
+    "node_modules/@lodder/grunt-postcss": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.1.1.tgz",
+      "integrity": "sha512-dgkDAUgjtCCCk7jsIBkDMhcL78y2reQ9YxqBpVJGa/0tX1Eus7GRWEn0QWqfFiHqqc3yrMQN+GtH8PUIZOBmDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff": "^5.0.0",
+        "maxmin": "^3.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "grunt": ">=1.0.4",
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/@lodder/grunt-postcss/node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -321,33 +352,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -384,16 +388,106 @@
         "lodash": "^4.17.14"
       }
     },
-    "node_modules/autoprefixer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-      "integrity": "sha512-1X4srCG0vAe2ArX9d3Kfkuo5yREFZwKE5mH+VHZHIhmx0V8UjDPAKmNgJlWxxNbCAraHiDPTcT2kc+3i73jR/Q==",
+    "node_modules/autoprefixer": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "browserslist": "~0.4.0",
-        "caniuse-db": "^1.0.30000214",
-        "num2fraction": "^1.1.0",
-        "postcss": "~4.1.12"
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/autoprefixer/node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/balanced-match": {
@@ -401,6 +495,19 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/body": {
       "version": "5.1.0",
@@ -436,16 +543,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browserslist": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
-      "integrity": "sha512-/JVhaf9S6ru3THyiuwX5j86pT79r5UtgwV3s6w+KpGlmUzPxfMbI5OBxO88iFtqgdqPuNirprachS3m1611qKA==",
-      "deprecated": "Browserslist 2 could fail on reading Browserslist >3.0 config used in other tools.",
-      "dev": true,
-      "dependencies": {
-        "caniuse-db": "^1.0.30000153"
-      }
-    },
     "node_modules/bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -465,27 +562,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/caniuse-db": {
-      "version": "1.0.30001474",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001474.tgz",
-      "integrity": "sha512-XbTs9Gt0asCiETyJCMFwy/cp8qT1TPpuo3itbqd566MykpnDZoIX4swxwF8nk1fS9mZbTUtagV4NOg4ndf697A==",
-      "dev": true
-    },
-    "node_modules/chalk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-      "integrity": "sha512-1TE3hpADga5iWinlcCpyhC7fTl9uQumLD8i2jJoJeVg7UbveY5jj7F6uCq8w0hQpSeLhaPn5QFe8e56toMVP1A==",
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
-      "dependencies": {
-        "ansi-styles": "^2.0.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^1.0.3",
-        "strip-ansi": "^2.0.1",
-        "supports-color": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "4.0.1",
@@ -600,15 +696,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/diff": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
-      "integrity": "sha512-9+sQRZoycCPesCSrnJci3QAbspUkUqJB9OidQlaSwsX0Nks2YigX2X0N4CaVmII2NlonNB2osJj9tALJFoVuIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -671,6 +758,13 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -686,11 +780,15 @@
         "string-template": "~0.2.1"
       }
     },
-    "node_modules/es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw==",
-      "dev": true
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -847,6 +945,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -883,15 +995,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/getobject": {
@@ -1004,24 +1107,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/grunt-autoprefixer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "integrity": "sha512-WlLnLOGoQFI/IQj6vbx+Kx/KMmJn5g1Fkx6rcp5+9VRIFwN46uSSi3BC8HMteHTZ/KA+zAqST957TkoiSDIujw==",
-      "dev": true,
-      "dependencies": {
-        "autoprefixer-core": "^5.1.7",
-        "chalk": "~1.0.0",
-        "diff": "~1.3.0",
-        "postcss": "^4.1.11"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      },
-      "peerDependencies": {
-        "grunt": ">=0.4.2"
       }
     },
     "node_modules/grunt-cli": {
@@ -1504,22 +1589,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/has-ansi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-      "integrity": "sha512-XwLzIec2hoj/LW9F3nCcQpEwZ5fDJ1LOc6SAgc0pz79CGiY9zmZhIkbf7OnK+tC36UhpQBa03HPt13QavGoF6Q==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^1.1.0",
-        "get-stdin": "^4.0.1"
-      },
-      "bin": {
-        "has-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -1739,17 +1808,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
-      "dev": true
-    },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1971,12 +2035,41 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nopt": {
       "version": "3.0.6",
@@ -1989,12 +2082,6 @@
       "bin": {
         "nopt": "bin/nopt.js"
       }
-    },
-    "node_modules/num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
-      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -2150,6 +2237,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2172,27 +2266,40 @@
       }
     },
     "node_modules/postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha512-aAutxE8MvL1bHylFMYb2c2nniFax8XDztHzZ+x5DVsNJnoW6VHvGSNSqdW3+ip255HCWfPjayVVFzMmyiL7opA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
-      }
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-      "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-      "dev": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
@@ -2403,21 +2510,6 @@
       "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
       "dev": true
     },
-    "node_modules/strip-ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-      "integrity": "sha512-2h8q2CP3EeOhDJ+jd932PRMpa3/pOJFGoF22J1U/DNbEK2gSW2DqeF46VjCXsSQXhC+k/l8/gaaRBQKL6hUPfQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^1.0.0"
-      },
-      "bin": {
-        "strip-ansi": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -2425,18 +2517,6 @@
       "dev": true,
       "bin": {
         "strip-json-comments": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-      "integrity": "sha512-OHbMkscHFRcNWEcW80fYhCrzAjheSIBwJChpFaBqA6zEz53nxumqi6ukciRb/UA0/v2nDNMk28ce/uBbYRDsng==",
-      "dev": true,
-      "bin": {
-        "supports-color": "cli.js"
       },
       "engines": {
         "node": ">=0.8.0"
@@ -2602,6 +2682,25 @@
     }
   },
   "dependencies": {
+    "@lodder/grunt-postcss": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lodder/grunt-postcss/-/grunt-postcss-3.1.1.tgz",
+      "integrity": "sha512-dgkDAUgjtCCCk7jsIBkDMhcL78y2reQ9YxqBpVJGa/0tX1Eus7GRWEn0QWqfFiHqqc3yrMQN+GtH8PUIZOBmDQ==",
+      "dev": true,
+      "requires": {
+        "diff": "^5.0.0",
+        "maxmin": "^3.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+          "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+          "dev": true
+        }
+      }
+    },
     "@parcel/watcher": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
@@ -2725,24 +2824,6 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
-      "integrity": "sha512-q5i8bFLg2wDfsuR56c1NzlJFPzVD+9mxhDrhqOGigEFa87OZHlF+9dWeGWzVTP/0ECiA/JUGzfzRr2t3eYORRw==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "dev": true
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2773,22 +2854,54 @@
         "lodash": "^4.17.14"
       }
     },
-    "autoprefixer-core": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.2.1.tgz",
-      "integrity": "sha512-1X4srCG0vAe2ArX9d3Kfkuo5yREFZwKE5mH+VHZHIhmx0V8UjDPAKmNgJlWxxNbCAraHiDPTcT2kc+3i73jR/Q==",
+    "autoprefixer": {
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "dev": true,
       "requires": {
-        "browserslist": "~0.4.0",
-        "caniuse-db": "^1.0.30000214",
-        "num2fraction": "^1.1.0",
-        "postcss": "~4.1.12"
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.28.7",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+          "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+          "dev": true,
+          "requires": {
+            "baseline-browser-mapping": "^2.10.44",
+            "caniuse-lite": "^1.0.30001806",
+            "electron-to-chromium": "^1.5.393",
+            "node-releases": "^2.0.51",
+            "update-browserslist-db": "^1.2.3"
+          }
+        },
+        "update-browserslist-db": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+          "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+          "dev": true,
+          "requires": {
+            "escalade": "^3.2.0",
+            "picocolors": "^1.1.1"
+          }
+        }
       }
     },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true
     },
     "body": {
@@ -2822,15 +2935,6 @@
         "fill-range": "^7.1.1"
       }
     },
-    "browserslist": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.4.0.tgz",
-      "integrity": "sha512-/JVhaf9S6ru3THyiuwX5j86pT79r5UtgwV3s6w+KpGlmUzPxfMbI5OBxO88iFtqgdqPuNirprachS3m1611qKA==",
-      "dev": true,
-      "requires": {
-        "caniuse-db": "^1.0.30000153"
-      }
-    },
     "bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -2847,24 +2951,11 @@
         "get-intrinsic": "^1.0.2"
       }
     },
-    "caniuse-db": {
-      "version": "1.0.30001474",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001474.tgz",
-      "integrity": "sha512-XbTs9Gt0asCiETyJCMFwy/cp8qT1TPpuo3itbqd566MykpnDZoIX4swxwF8nk1fS9mZbTUtagV4NOg4ndf697A==",
+    "caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true
-    },
-    "chalk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
-      "integrity": "sha512-1TE3hpADga5iWinlcCpyhC7fTl9uQumLD8i2jJoJeVg7UbveY5jj7F6uCq8w0hQpSeLhaPn5QFe8e56toMVP1A==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^2.0.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^1.0.3",
-        "strip-ansi": "^2.0.1",
-        "supports-color": "^1.3.0"
-      }
     },
     "chokidar": {
       "version": "4.0.1",
@@ -2952,12 +3043,6 @@
       "dev": true,
       "optional": true
     },
-    "diff": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.3.2.tgz",
-      "integrity": "sha512-9+sQRZoycCPesCSrnJci3QAbspUkUqJB9OidQlaSwsX0Nks2YigX2X0N4CaVmII2NlonNB2osJj9tALJFoVuIA==",
-      "dev": true
-    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -3013,6 +3098,12 @@
       "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
       "dev": true
     },
+    "electron-to-chromium": {
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "dev": true
+    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
@@ -3028,10 +3119,10 @@
         "string-template": "~0.2.1"
       }
     },
-    "es6-promise": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
-      "integrity": "sha512-oyOjMhyKMLEjOOtvkwg0G4pAzLQ9WdbbeX7WdqKzvYXu+UFgD0Zo/Brq5Q49zNmnGPPzV5rmYvrr0jz1zWx8Iw==",
+    "escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -3146,6 +3237,12 @@
         "for-in": "^1.0.1"
       }
     },
+    "fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3177,12 +3274,6 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
       }
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha512-F5aQMywwJ2n85s4hJPTT9RPxGmubonuB10MNYo17/xph174n2MIR33HRguhzVag10O/npM7SPk73LMZNP+FaWw==",
-      "dev": true
     },
     "getobject": {
       "version": "1.0.2",
@@ -3266,21 +3357,9 @@
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
+        "js-yaml": "3.15.0",
         "minimatch": "~3.0.4",
         "nopt": "~3.0.6"
-      }
-    },
-    "grunt-autoprefixer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/grunt-autoprefixer/-/grunt-autoprefixer-3.0.4.tgz",
-      "integrity": "sha512-WlLnLOGoQFI/IQj6vbx+Kx/KMmJn5g1Fkx6rcp5+9VRIFwN46uSSi3BC8HMteHTZ/KA+zAqST957TkoiSDIujw==",
-      "dev": true,
-      "requires": {
-        "autoprefixer-core": "^5.1.7",
-        "chalk": "~1.0.0",
-        "diff": "~1.3.0",
-        "postcss": "^4.1.11"
       }
     },
     "grunt-cli": {
@@ -3642,16 +3721,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
-      "integrity": "sha512-XwLzIec2hoj/LW9F3nCcQpEwZ5fDJ1LOc6SAgc0pz79CGiY9zmZhIkbf7OnK+tC36UhpQBa03HPt13QavGoF6Q==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^1.1.0",
-        "get-stdin": "^4.0.1"
-      }
-    },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
@@ -3826,16 +3895,10 @@
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
-    "js-base64": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
-      "integrity": "sha512-f+5mYh8iF7FlF7zgmj/yqvvYQUHI0kAxGiLjIfNxZzqJ7RQNc4sjgp8crVJw0Kzv2O6aFGZWgMTnO71I9utHSg==",
-      "dev": true
-    },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4008,12 +4071,24 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true
+    },
     "node-addon-api": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true,
       "optional": true
+    },
+    "node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true
     },
     "nopt": {
       "version": "3.0.6",
@@ -4023,12 +4098,6 @@
       "requires": {
         "abbrev": "1"
       }
-    },
-    "num2fraction": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-      "integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
-      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4148,6 +4217,12 @@
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -4161,26 +4236,21 @@
       "dev": true
     },
     "postcss": {
-      "version": "4.1.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.1.16.tgz",
-      "integrity": "sha512-aAutxE8MvL1bHylFMYb2c2nniFax8XDztHzZ+x5DVsNJnoW6VHvGSNSqdW3+ip255HCWfPjayVVFzMmyiL7opA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "requires": {
-        "es6-promise": "~2.3.0",
-        "js-base64": "~2.1.8",
-        "source-map": "~0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==",
-          "dev": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",
@@ -4326,25 +4396,10 @@
       "integrity": "sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==",
       "dev": true
     },
-    "strip-ansi": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
-      "integrity": "sha512-2h8q2CP3EeOhDJ+jd932PRMpa3/pOJFGoF22J1U/DNbEK2gSW2DqeF46VjCXsSQXhC+k/l8/gaaRBQKL6hUPfQ==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^1.0.0"
-      }
-    },
     "strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
-      "integrity": "sha512-OHbMkscHFRcNWEcW80fYhCrzAjheSIBwJChpFaBqA6zEz53nxumqi6ukciRb/UA0/v2nDNMk28ce/uBbYRDsng==",
       "dev": true
     },
     "supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -13,14 +13,22 @@
     "watch": "grunt watch"
   },
   "devDependencies": {
+    "@lodder/grunt-postcss": "^3.1.1",
+    "autoprefixer": "^10.5.4",
     "grunt": "^1.6.1",
-    "grunt-autoprefixer": "~3.0.4",
     "grunt-contrib-cssmin": "^5.0.0",
     "grunt-contrib-jshint": "^3.2.0",
     "grunt-contrib-uglify": "~5.2.2",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-sass": "~3.1.0",
     "grunt-wp-readme-to-markdown": "~2.1.0",
+    "postcss": "^8.5.23",
     "sass": "^1.82.0"
+  },
+  "browserslist": [
+    "last 5 versions"
+  ],
+  "overrides": {
+    "js-yaml": "3.15.0"
   }
 }


### PR DESCRIPTION
## Summary

Promotes to `main` the dev-dependency security fixes that have accumulated on `develop`, plus the SITE-5995 plugin-check workflow. Five files, `+445 / -326`, of which `package-lock.json` is `+693 / -...` regenerated noise.

`develop` is the working branch on this repo, but vulntools reads `main`, so those fixes are invisible to the scanners today. `main` is also the default branch and has had no wp.org plugin-check coverage at all.

Nothing here is plugin runtime code. No file under `includes/`, `template/`, `templates/`, `views/` or `solr-power.php` is touched, and no version string moves.

Per Phil in [the squad thread](https://pantheon.slack.com/archives/C0AD8TY61D0/p1785848771769979): since these are all dev deps, PR them to main with `[ci skip]` and reconcile back to develop, rather than cutting a release.

## What the diff actually contains

| File | Change | Ticket |
|---|---|---|
| `composer.json` | `+6` | VUL-24495, VUL-25207 |
| `package.json` | `+9 / -1` | VUL-24442, VUL-25001, VUL-25002, VUL-23981, VUL-26008 |
| `Gruntfile.js` | `+6 / -6` | VUL-26008 |
| `package-lock.json` | regenerated | all of the above |
| `.github/workflows/wporg-validator.yml` | `+50`, new file | SITE-5995 |

### `composer.json`

Adds a `config.audit.ignore` block and nothing else:

```json
"audit": {
    "ignore": [
        "GHSA-g446-98w2-8p5w",
        "GHSA-c2w2-prh8-qm98"
    ]
}
```

- `GHSA-g446-98w2-8p5w` is *Guzzle: Cookie Disclosure and Injection via IP-Address Domains* (`guzzlehttp/guzzle`).
- `GHSA-c2w2-prh8-qm98` is *guzzlehttp/psr7: Host Confusion via Weak URI Host Validation* (`guzzlehttp/psr7`).

Both reach this repo only through the dev toolchain. `require` is untouched and still resolves solarium/solarium and symfony/event-dispatcher.

### `package.json` and `Gruntfile.js`

`grunt-autoprefixer ~3.0.4` is dead upstream and pulls the vulnerable transitive tree. It is replaced with the maintained fork plus postcss 8:

- removed: `grunt-autoprefixer`
- added: `@lodder/grunt-postcss ^3.1.1`, `autoprefixer ^10.5.4`, `postcss ^8.5.23`
- added: `overrides: { "js-yaml": "3.15.0" }`, which is the js-yaml pin covering the four solr-power js-yaml tickets

`Gruntfile.js` follows the rename in four places: the task config block `autoprefixer:` becomes `postcss:`, `loadNpmTasks` switches to `@lodder/grunt-postcss`, and both the `watch` task list and the `default` registration swap `'autoprefixer'` for `'postcss'`.

One behavior detail worth checking on review: browser targeting moved rather than disappeared. The Gruntfile's `options.browsers = ['last 5 versions']` is gone, because grunt-postcss does not take it, and the same value now lives in `package.json` as a top-level `browserslist` key, which is where autoprefixer 10 reads it from. Same targets, different home.

### `package-lock.json`

Regenerated, not hand-edited. Resolved versions in the committed lockfile:

| Package | Resolved |
|---|---|
| `postcss` | 8.5.25 |
| `autoprefixer` | 10.5.4 |
| `@lodder/grunt-postcss` | 3.1.1 |
| `js-yaml` | 3.15.0 (single entry in the tree) |
| `grunt-autoprefixer` | absent |

Lockfile `version` stays `2.6.0`, matching `main`.

### `.github/workflows/wporg-validator.yml`

`167fa40` is a `git cherry-pick -x` of `dc70ec2` from `develop`, where it landed via #657. Byte-identical to develop's copy, verified with `git diff origin/develop HEAD -- .github/workflows/wporg-validator.yml` returning empty, so it will not conflict when `main` is reconciled back into `develop`.

The workflow builds a `wp dist-archive` on PHP 8.4 and runs `wordpress/plugin-check-action@6f5a57e` (1.1.5) against it. It triggers on `pull_request` and on `push` to `main`.

## `Validate Plugin` will be red here, and on `main` after merge

Expected, not a regression. `main` does not yet carry the SITE-5995 compliance fixes:

- `readme.txt` on `main` has `Tested up to: 6.7.1`, which trips `outdated_tested_upto_header`. That is an ERROR, not a warning.
- 12 `WordPress.Security.EscapeOutput.OutputNotEscaped` ERRORs across `template/s4w_search.php`, `template/s4wp_search.php`, `includes/legacy-functions.php` and `includes/class-solrpower-sync.php`. Those fixes are in #658, open against `develop` and green there.

`Validate Plugin` is **not** a required check on `main`. The ruleset requires only `Wiz IaC Scanner`, `Wiz Vulnerability Scanner`, `Wiz Data Scanner` and two approvals, so the red does not block this merge. It goes green once #658 lands on `develop` and `develop` is promoted to `main`.

## Deliberately left on `develop`

- `ea045c3` bumps 2.6.0 to 2.6.1-dev across `solr-power.php`, `readme.txt`, `README.md`, `CHANGELOG.md` and `package.json`. Prod-visible version string, implies a release.
- `d8893c3` new wp.org listing imagery.

## Why `[ci skip]` is in the title and not the commits

`.github/workflows/build-tag.yml` triggers on `push` to `main` and cuts a tag and release. GitHub decides whether to skip based on the **HEAD commit message of the push**, which for a squash merge is the squash commit message, defaulting to the PR title.

So `[ci skip]` belongs in the PR title. Putting it in the branch commits instead would also skip this PR's own validation, which we want to run.

**When merging: squash, and keep `[ci skip]` in the squash commit message.** If the repo is set to a merge commit instead, put `[ci skip]` in the merge commit message.

Safety net: `build-tag-release@v0` runs with `draft: "true"`, so even if the skip does not take effect the release is created as a draft rather than published.

## Verification

- `grunt default` run locally, passes end to end including the `postcss:files` task, producing both stylesheets and their sourcemaps. This matters because the repo has **no CI coverage for the npm/grunt build** (tracked in #669), so CI cannot catch a broken build here.
- `composer validate` reports `./composer.json is valid`, no lockfile staleness.
- Resolved lockfile versions confirmed directly against the committed `package-lock.json`, table above.
- Both GHSA IDs resolved against the GitHub Advisory API to confirm they are the guzzle and psr7 advisories, not something else.
- `wporg-validator.yml` confirmed byte-identical to develop's copy.

## Follow-up

- Reconcile `main` back into `develop` after this merges, so the two do not diverge further.
- Merge #658 to `develop`, then promote `develop` to `main`, which turns `Validate Plugin` green on `main`.
- VUL-25911 (wpcs) is **not** addressed here. Blocked by `config.platform.php` pinned to 7.1 while wpcs 3.4.1 requires `php >=7.2`, and needs a product decision on the plugin's minimum PHP. Tracked separately.

## Test plan

- [ ] Wiz scanners green
- [ ] `Validate Plugin` reports only the known `main` ERRORs listed above, nothing beyond them
- [ ] Merge as a squash with `[ci skip]` retained in the commit message
- [ ] Confirm `Build, Tag, and Release` did not run on the resulting push to `main`
- [ ] Confirm no new tag or release was created
- [ ] Reconcile `main` back to `develop`
