### PR TITLE
fix: bump js-yaml and brace-expansion to remediate multiple VULs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1809,11 +1809,10 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2917,9 +2916,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -3357,7 +3356,7 @@
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "3.15.0",
+        "js-yaml": "3.15.1",
         "minimatch": "~3.0.4",
         "nopt": "~3.0.6"
       }
@@ -3896,9 +3895,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -4062,7 +4061,7 @@
       "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.18"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "last 5 versions"
   ],
   "overrides": {
-    "js-yaml": "3.15.0"
+    "js-yaml": "3.15.1",
+    "brace-expansion": "1.1.18"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps the `js-yaml` override 3.15.0 → 3.15.1, fixing CVE-2026-59870 (quadratic CPU consumption in `!!omap` resolution) — the prior pin only addressed CVE-2026-59869.
- Adds a `brace-expansion` override 1.1.18, fixing a chain of DoS advisories (GHSA-v6h2-p8h4-qcjw, GHSA-f886-m6hf-6m8v, GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895) up through 1.1.17.
- Both are transitive dev-dependencies pulled in via `grunt`/`minimatch` and only affect the local/CI build toolchain — not the shipped WordPress plugin.
- Verified with `npm audit` that both packages are clean post-bump, and confirmed `grunt default` still builds successfully.

## Jira Tickets Resolved
- [VUL-24442](https://getpantheon.atlassian.net/browse/VUL-24442)
- [VUL-27055](https://getpantheon.atlassian.net/browse/VUL-27055)

## CVEs Addressed

| Package | CVE/GHSA | Severity | Description | Fixed in |
|---|---|---|---|---|
| js-yaml | CVE-2026-59870 (GHSA-5p4m-2wfm-xmqj) | High | Quadratic CPU consumption in `!!omap` resolution | 3.15.1 |
| brace-expansion | GHSA-v6h2-p8h4-qcjw, GHSA-f886-m6hf-6m8v, GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 | Various | Chain of DoS advisories | 1.1.18 |


[VUL-24442]: https://getpantheon.atlassian.net/browse/VUL-24442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-27055]: https://getpantheon.atlassian.net/browse/VUL-27055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ